### PR TITLE
fix(storage): replace print with structured logging

### DIFF
--- a/pkg/storage/namespaces/namespaces.go
+++ b/pkg/storage/namespaces/namespaces.go
@@ -4,13 +4,14 @@ package namespaces
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/kommodity-io/kommodity/pkg/logging"
 	storageerr "github.com/kommodity-io/kommodity/pkg/storage"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -135,17 +136,23 @@ func (namespaceStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) [
 }
 
 // PrepareForUpdate sets defaults for updated objects.
-func (namespaceStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
+func (namespaceStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	logger := logging.FromContext(ctx).With(zap.String("component", "namespace-storage"))
+
 	newNamespace, success := obj.(*corev1.Namespace)
 	if !success {
-		log.Printf("expected *corev1.Namespace, got %T", obj)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Namespace"),
+			zap.String("received", fmt.Sprintf("%T", obj)))
 
 		return
 	}
 
 	oldNamespace, success := old.(*corev1.Namespace)
 	if !success {
-		log.Printf("expected *corev1.Namespace, got %T", obj)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Namespace"),
+			zap.String("received", fmt.Sprintf("%T", old)))
 
 		return
 	}

--- a/pkg/storage/secrets/secrets.go
+++ b/pkg/storage/secrets/secrets.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
 	"path"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/kommodity-io/kommodity/pkg/logging"
 	"github.com/kommodity-io/kommodity/pkg/storage"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -165,17 +166,23 @@ func warningsForSecret(secret *corev1.Secret) []string {
 }
 
 // PrepareForUpdate sets defaults for updated objects.
-func (secretStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
+func (secretStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	logger := logging.FromContext(ctx).With(zap.String("component", "secret-storage"))
+
 	newSecret, success := obj.(*corev1.Secret)
 	if !success {
-		log.Printf("expected *corev1.Secret, got %T", obj)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Secret"),
+			zap.String("received", fmt.Sprintf("%T", obj)))
 
 		return
 	}
 
 	oldSecret, success := old.(*corev1.Secret)
 	if !success {
-		log.Printf("expected *corev1.Secret, got %T", obj)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Secret"),
+			zap.String("received", fmt.Sprintf("%T", old)))
 
 		return
 	}

--- a/pkg/storage/services/services.go
+++ b/pkg/storage/services/services.go
@@ -4,13 +4,14 @@ package services
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/kommodity-io/kommodity/pkg/logging"
 	storageerr "github.com/kommodity-io/kommodity/pkg/storage"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -131,10 +132,14 @@ func (serviceStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate sets defaults for new objects.
-func (serviceStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
+func (serviceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	logger := logging.FromContext(ctx).With(zap.String("component", "service-storage"))
+
 	service, success := obj.(*corev1.Service)
 	if !success {
-		log.Printf("expected *corev1.Service, got %T", obj)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Service"),
+			zap.String("received", fmt.Sprintf("%T", obj)))
 
 		return
 	}
@@ -148,17 +153,23 @@ func (serviceStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []s
 }
 
 // PrepareForUpdate sets defaults for updated objects.
-func (serviceStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
+func (serviceStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	logger := logging.FromContext(ctx).With(zap.String("component", "service-storage"))
+
 	newService, success := obj.(*corev1.Service)
 	if !success {
-		log.Printf("expected *corev1.Service, got %T", obj)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Service"),
+			zap.String("received", fmt.Sprintf("%T", obj)))
 
 		return
 	}
 
 	oldService, success := old.(*corev1.Service)
 	if !success {
-		log.Printf("expected *corev1.Service, got %T", old)
+		logger.Error("Received unexpected type",
+			zap.String("expected", "*corev1.Service"),
+			zap.String("received", fmt.Sprintf("%T", old)))
 
 		return
 	}


### PR DESCRIPTION
### Description

Switched over the logging in storage (namespaces, secrets, and services) to use structured logging with `zap` instead of the standard library `log` package. Should make logs more consistent and easier to grep through.

### Changes made

#### Logging

- Replaced the old `log.Printf` calls with zap logger in the `PrepareForUpdate` and `PrepareForCreate` methods across namespace, secret, and service strategies
- Added a `component` field to each log entry so it can be tracked where the errors are coming from more easily

#### Dependencies

- Imported the `logging` package and `zap` in the storage files (`pkg/storage/namespaces/namespaces.go`, `pkg/storage/secrets/secrets.go`, and `pkg/storage/services/services.go`)