### PR TITLE
fix(ci): allow release pipeline to push to GH container registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Signed-off-by: Paul Thuriot <pth@corti.ai>
