### PR TITLE
fix(charts): only add additionalVolumes to sha if set

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.4
+version: 0.12.5
 # The downstream Talos version deployed by the chart.
 appVersion: "1.12.2"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -103,7 +103,9 @@ Any values that should trigger a new Talos config template when changed should b
 {{- $_ := set $data "labels" (dig "labels" "" .poolValues) -}}
 {{- $_ := set $data "annotations" (dig "annotations" "" .poolValues) -}}
 {{- $_ := set $data "taints" (dig "taints" "" .poolValues) -}}
-{{- $_ := set $data "additionalVolumes" (dig "additionalVolumes" "" .poolValues) -}}
+{{- with (dig "additionalVolumes" "" .poolValues) -}}
+	{{- $_ := set $data "additionalVolumes" . -}}
+{{- end -}}
 {{- toJson $data | sha256sum | trunc 6 -}}
 {{- end -}}
 


### PR DESCRIPTION
Otherwise, all nodepools in all envs will have to be rolled (new name for TalosConfigTemplate)

Signed-off-by: Paul Thuriot <pth@corti.ai>
