### PR TITLE
fix(scripts): make teardown-cluster idempotent and unstick kubevirtcluster

### DIFF
--- a/scripts/teardown-cluster.sh
+++ b/scripts/teardown-cluster.sh
@@ -23,7 +23,7 @@ case "${confirm}" in
     ;;
 esac
 
-${HELM} uninstall "${CLUSTER_NAME}"
+${HELM} uninstall --ignore-not-found "${CLUSTER_NAME}"
 
 # Wait for machines to be deleted
 echo "⏳ Waiting for machines to be deleted..."
@@ -36,6 +36,13 @@ while true; do
   sleep 5
 done
 echo "✅ All machines deleted."
+
+# Remove finalizer on KubevirtCluster if present
+if ${KUBECTL} get kubevirtcluster "${CLUSTER_NAME}" >/dev/null 2>&1; then
+  echo "🧹 Removing finalizers from KubevirtCluster/${CLUSTER_NAME}..."
+  ${KUBECTL} patch kubevirtcluster "${CLUSTER_NAME}" \
+    --type=merge -p '{"metadata":{"finalizers":[]}}'
+fi
 
 # Wait for Cluster object to be deleted
 CLUSTER_DELETE_TIMEOUT="${CLUSTER_DELETE_TIMEOUT:-600s}"

--- a/scripts/teardown-cluster.sh
+++ b/scripts/teardown-cluster.sh
@@ -37,10 +37,21 @@ while true; do
 done
 echo "✅ All machines deleted."
 
-# Remove finalizers on KubevirtCluster if present (ignore if already gone)
+# Remove finalizers on KubevirtCluster if present.
+# Tolerate NotFound only; rethrow any other error.
 echo "🧹 Removing finalizers from KubevirtCluster/${CLUSTER_NAME} (if present)..."
-${KUBECTL} patch kubevirtcluster "${CLUSTER_NAME}" \
-  --type=merge -p '{"metadata":{"finalizers":[]}}' --ignore-not-found
+patch_out=$(${KUBECTL} patch kubevirtcluster "${CLUSTER_NAME}" \
+  --type=merge -p '{"metadata":{"finalizers":[]}}' 2>&1) && patch_rc=0 || patch_rc=$?
+if [ "$patch_rc" -ne 0 ]; then
+  if echo "$patch_out" | grep -qi 'not found'; then
+    echo "   KubevirtCluster/${CLUSTER_NAME} not present, skipping."
+  else
+    echo "$patch_out" >&2
+    exit "$patch_rc"
+  fi
+else
+  echo "$patch_out"
+fi
 
 # Wait for Cluster object to be deleted
 CLUSTER_DELETE_TIMEOUT="${CLUSTER_DELETE_TIMEOUT:-600s}"

--- a/scripts/teardown-cluster.sh
+++ b/scripts/teardown-cluster.sh
@@ -13,7 +13,7 @@ HELM="helm --kube-context=${KUBE_CONTEXT}"
 
 echo "🗑️ Tearing down cluster: $CLUSTER_NAME"
 echo "   Context: ${KUBE_CONTEXT}"
-echo "   This will run: ${HELM} uninstall ${CLUSTER_NAME}"
+echo "   This will run: ${HELM} uninstall --ignore-not-found ${CLUSTER_NAME}"
 read -r -p "Proceed with helm uninstall? [y/N] " confirm
 case "${confirm}" in
   y) ;;
@@ -37,12 +37,10 @@ while true; do
 done
 echo "✅ All machines deleted."
 
-# Remove finalizer on KubevirtCluster if present
-if ${KUBECTL} get kubevirtcluster "${CLUSTER_NAME}" >/dev/null 2>&1; then
-  echo "🧹 Removing finalizers from KubevirtCluster/${CLUSTER_NAME}..."
-  ${KUBECTL} patch kubevirtcluster "${CLUSTER_NAME}" \
-    --type=merge -p '{"metadata":{"finalizers":[]}}'
-fi
+# Remove finalizers on KubevirtCluster if present (ignore if already gone)
+echo "🧹 Removing finalizers from KubevirtCluster/${CLUSTER_NAME} (if present)..."
+${KUBECTL} patch kubevirtcluster "${CLUSTER_NAME}" \
+  --type=merge -p '{"metadata":{"finalizers":[]}}' --ignore-not-found
 
 # Wait for Cluster object to be deleted
 CLUSTER_DELETE_TIMEOUT="${CLUSTER_DELETE_TIMEOUT:-600s}"


### PR DESCRIPTION
## Summary
- `helm uninstall --ignore-not-found` so reruns after partial teardown do not fail with `release: not found`
- Strip finalizers on `KubevirtCluster/<name>` before waiting on `Cluster` deletion, to avoid hangs when the provider controller is unavailable

## Test plan
- [ ] Run `./scripts/teardown-cluster.sh <ctx> <cluster>` twice in a row; second run completes without error
- [ ] Run against a cluster whose `KubevirtCluster` is stuck on a finalizer; Cluster object deletes within timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)