### PR TITLE
fix(kine): enable watch cacher for REST storage [PLA-5867]

### DIFF
--- a/pkg/kine/rest.go
+++ b/pkg/kine/rest.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 )
@@ -33,7 +34,7 @@ func (g *RESTOptionsGetter) GetRESTOptions(resource schema.GroupResource,
 		StorageConfig:           g.StorageConfig.ForResource(resource),
 		DeleteCollectionWorkers: 1,
 		EnableGarbageCollection: true,
-		Decorator:               genericregistry.UndecoratedStorage,
+		Decorator:               registry.StorageWithCacher(),
 		ResourcePrefix:          resource.Resource,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Switch `RESTOptionsGetter.Decorator` from `UndecoratedStorage` to `registry.StorageWithCacher()` in `pkg/kine/rest.go`
- Every CRD served via `apiextensions-apiserver` now gets a server-side `cacher.Cacher` instead of a raw etcd3 client per client watch

## Why

`UndecoratedStorage` is upstream-flagged as event-registry-only (`k8s.io/apiserver/pkg/registry/generic/storage_decorator.go:53`). With it set as default, every WATCH from a client becomes its own raw gRPC stream to kine — no server-side reflector, no buffer, no auto-reconnect. When a stream dies (idle timeout / kine restart / postgres reconnect) the resource's watch is lost; different CRDs die independently, producing asymmetric failures.

Observed in sbx: `kommodity-sbx-app` (revision 0000015, image `v0.131.0`, 46h uptime) had CAPK `KubevirtMachineReconciler` invoked **zero** times over 24h while `KubevirtClusterReconciler` worked fine on the same process. 8 `KubevirtMachine`s stuck in `Provisioning` with no finalizer/status/events; container app restart re-established watches and CAPK began reconciling within seconds.

`StorageWithCacher` is the upstream default — one reflector per resource, fans events to N clients, auto-reconnects on upstream watch failure.

Tracking: PLA-5867

## Test plan

- [ ] Verify build / lint / unit tests pass
- [ ] Deploy to sbx, recreate `sbx-par02` KubeVirt cluster, confirm KubevirtMachines reconcile within seconds (no restart needed)
- [ ] Long-running soak: 24h+ uptime with periodic kine/postgres restarts; confirm CRD watches survive
- [ ] Memory check: cacher holds full resource list; monitor for runaway memory on high-volume kinds (Secrets/ConfigMaps/Events) and add per-resource `CacheSize` overrides via `StorageFactoryRestOptionsFactory` if needed