### PR TITLE
fix(server): apply Secret stringData→data merge in embedded apiserver

### DIFF
--- a/pkg/storage/secrets/secrets.go
+++ b/pkg/storage/secrets/secrets.go
@@ -129,7 +129,16 @@ func (secretStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate sets defaults for new objects.
-func (secretStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {}
+func (secretStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		log.Printf("expected *corev1.Secret, got %T", obj)
+
+		return
+	}
+
+	mergeStringDataIntoData(secret)
+}
 
 // WarningsOnCreate returns warnings for create operations.
 func (secretStrategy) WarningsOnCreate(_ context.Context, obj runtime.Object) []string {
@@ -175,6 +184,28 @@ func (secretStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Objec
 	if len(newSecret.Type) == 0 {
 		newSecret.Type = oldSecret.Type
 	}
+
+	mergeStringDataIntoData(newSecret)
+}
+
+// mergeStringDataIntoData folds Secret.StringData into Secret.Data (StringData
+// overwrites Data on key collision) and clears StringData. Stock kube-apiserver
+// achieves this via the v1→internal conversion; since the embedded apiserver
+// stores corev1.Secret directly, the merge has to happen explicitly here.
+func mergeStringDataIntoData(secret *corev1.Secret) {
+	if len(secret.StringData) == 0 {
+		return
+	}
+
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte, len(secret.StringData))
+	}
+
+	for k, v := range secret.StringData {
+		secret.Data[k] = []byte(v)
+	}
+
+	secret.StringData = nil
 }
 
 // WarningsOnUpdate returns warnings for update operations.

--- a/pkg/storage/secrets/secrets_test.go
+++ b/pkg/storage/secrets/secrets_test.go
@@ -1,0 +1,88 @@
+//nolint:testpackage // White-box test exercises the unexported strategy directly.
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testSecretName = "s"
+	testNamespace  = "ns"
+	keyFoo         = "foo"
+	keyKeep        = "keep"
+)
+
+func TestPrepareForCreate_MergesStringDataIntoData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    *corev1.Secret
+		wantData map[string][]byte
+	}{
+		{
+			name: "stringData populates empty data",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespace},
+				StringData: map[string]string{keyFoo: "bar"},
+			},
+			wantData: map[string][]byte{keyFoo: []byte("bar")},
+		},
+		{
+			name: "stringData overrides data on key collision",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespace},
+				Data:       map[string][]byte{keyFoo: []byte("old"), keyKeep: []byte("v")},
+				StringData: map[string]string{keyFoo: "new"},
+			},
+			wantData: map[string][]byte{keyFoo: []byte("new"), keyKeep: []byte("v")},
+		},
+		{
+			name: "nil stringData leaves data untouched",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespace},
+				Data:       map[string][]byte{keyFoo: []byte("bar")},
+			},
+			wantData: map[string][]byte{keyFoo: []byte("bar")},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			secretStrategy{}.PrepareForCreate(context.Background(), testCase.input)
+
+			assert.Equal(t, testCase.wantData, testCase.input.Data)
+			assert.Empty(t, testCase.input.StringData, "StringData should be cleared after merge")
+		})
+	}
+}
+
+func TestPrepareForUpdate_MergesStringDataIntoData(t *testing.T) {
+	t.Parallel()
+
+	oldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespace},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{keyFoo: []byte("old")},
+	}
+
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespace},
+		Data:       map[string][]byte{keyFoo: []byte("old"), keyKeep: []byte("v")},
+		StringData: map[string]string{keyFoo: "new"},
+	}
+
+	secretStrategy{}.PrepareForUpdate(context.Background(), newSecret, oldSecret)
+
+	require.Equal(t, corev1.SecretTypeOpaque, newSecret.Type, "empty type should inherit from old")
+	assert.Equal(t, map[string][]byte{keyFoo: []byte("new"), keyKeep: []byte("v")}, newSecret.Data)
+	assert.Empty(t, newSecret.StringData)
+}


### PR DESCRIPTION
## Summary
- The embedded apiserver stores `corev1.Secret` directly via [pkg/storage/secrets/secrets.go](pkg/storage/secrets/secrets.go), bypassing the upstream v1→internal conversion that normally folds `StringData` into `Data`. Result: `kubectl apply` of a Secret with `stringData` leaves `.data` empty, and any controller reading `secret.Data["..."]` from client-go (CAPZ, etc.) sees nothing.
- Fix: perform the merge explicitly in the secret strategy's `PrepareForCreate` and `PrepareForUpdate`, matching upstream semantics — `StringData` overwrites `Data` on key collision and `StringData` is cleared after merge so the server response no longer echoes it back.
- Adds a white-box regression test under [pkg/storage/secrets/secrets_test.go](pkg/storage/secrets/secrets_test.go) covering create, update (with type inheritance), key-collision precedence, and the no-op path.

## Test plan
- [x] `go test ./pkg/storage/secrets/...`
- [x] `golangci-lint run pkg/storage/secrets/...`
- [ ] Manual repro from the bug report:
  - `make setup && make run`
  - `kubectl apply` a Secret with `stringData: { foo: bar }`
  - Confirm `kubectl get secret ... -o jsonpath='{.data.foo}'` now returns the base64 of `bar` and `stringData` is absent from the response.
- [ ] Confirm downstream controllers (CAPZ) now observe `secret.Data["..."]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)