### PR TITLE
fix(provider): exclude AzureManagedControlPlane CRD from fetch-providers

### DIFF
--- a/pkg/provider/providers.yaml
+++ b/pkg/provider/providers.yaml
@@ -72,6 +72,12 @@ providers:
       - AzureASOManagedControlPlaneTemplate
       - AzureASOManagedMachinePool
       - AzureASOManagedMachinePoolTemplate
+      - AzureManagedCluster
+      - AzureManagedClusterTemplate
+      - AzureManagedControlPlane
+      - AzureManagedControlPlaneTemplate
+      - AzureManagedMachinePool
+      - AzureManagedMachinePoolTemplate
       - BastionHost
       - FleetsMember
       - ManagedCluster


### PR DESCRIPTION
## Summary

- Added 6 AKS-only `AzureManaged*` CRDs to the `azure` provider `deny_list` in `pkg/provider/providers.yaml`
- Kommodity deploys VM-based clusters via Talos Linux and never uses AKS managed control planes, so these CRDs serve no purpose in this codebase
- Previously, the entries were filtered out only because CAPZ v1.21.0 marks their sole `v1beta1` version as `deprecated: true` — a fragile implicit dependency on upstream deprecation state

### CRDs added to deny_list

| CRD | Reason |
|-----|--------|
| `AzureManagedCluster` | AKS-only, Kommodity is VM/Talos-only |
| `AzureManagedClusterTemplate` | AKS-only |
| `AzureManagedControlPlane` | AKS-only |
| `AzureManagedControlPlaneTemplate` | AKS-only |
| `AzureManagedMachinePool` | AKS-only |
| `AzureManagedMachinePoolTemplate` | AKS-only |

### Why this matters

Without an explicit deny_list entry, if CAPZ adds a non-deprecated version of any of these CRDs in a future release, the files would re-appear as untracked files on every `make fetch-providers` / `make generate` run, dirtying the worktree and confusing developers.

The existing `AzureASOManagedCluster/ControlPlane/MachinePool` family (ASO-flavour managed types) was already correctly excluded. This PR aligns the non-ASO managed family to the same treatment.

## Test plan

- [ ] `make fetch-providers` produces no untracked files under `pkg/provider/crds/azure/`
- [ ] `git status` is clean after `make fetch-providers` (only `pkg/provider/providers.yaml` changed on the branch)
- [ ] `go build ./...` succeeds
- [ ] `golangci-lint run ./pkg/provider/...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)