### PR TITLE
feat(ui): add control plane details and other UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Caddyfile
 # Terraform files
 .terraform*
 .debug/
+.playwright-mcp/

--- a/pkg/ui/api/age.go
+++ b/pkg/ui/api/age.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	hoursPerDay   = 24
+	daysPerMonth  = 30
+	daysPerYear   = 365
+	hoursPerMonth = hoursPerDay * daysPerMonth
+	hoursPerYear  = hoursPerDay * daysPerYear
+)
+
+// FormatAge returns a short human-readable age string (e.g. "5m", "2h", "3d", "4mo", "1y")
+// computed from the given creation timestamp. Mirrors kubectl's HumanDuration shorthand.
+func FormatAge(creation time.Time) string {
+	if creation.IsZero() {
+		return UnknownVersion
+	}
+
+	delta := max(time.Since(creation), 0)
+
+	switch {
+	case delta < time.Minute:
+		return fmt.Sprintf("%ds", int(delta.Seconds()))
+	case delta < time.Hour:
+		return fmt.Sprintf("%dm", int(delta.Minutes()))
+	case delta < hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dh", int(delta.Hours()))
+	case delta < daysPerMonth*hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dd", int(delta.Hours()/hoursPerDay))
+	case delta < daysPerYear*hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dmo", int(delta.Hours()/hoursPerMonth))
+	default:
+		return fmt.Sprintf("%dy", int(delta.Hours()/hoursPerYear))
+	}
+}

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	taloscontrolplanev1 "github.com/siderolabs/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	"go.uber.org/zap"
 	clientgoclientset "k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -15,7 +16,16 @@ import (
 type ClusterDetail struct {
 	ClusterInfo
 
+	ControlPlane       *ControlPlaneDetail
 	MachineDeployments []MachineDeploymentDetail
+}
+
+// ControlPlaneDetail holds information about a control plane.
+type ControlPlaneDetail struct {
+	Name     string
+	Phase    string
+	Replicas *int32
+	Machines []MachineDetail
 }
 
 // MachineDeploymentDetail holds information about a MachineDeployment.
@@ -66,15 +76,86 @@ func GetClusterDetail(
 		return nil, fmt.Errorf("%w: %s", ErrClusterNotFound, clusterName)
 	}
 
+	// Fetch all machines for the cluster once and group them.
+	machineList := &clusterv1.MachineList{}
+
+	err = client.List(ctx, machineList, ctrlclient.InNamespace(DefaultNamespace), ctrlclient.MatchingLabels{
+		ClusterNameLabel: clusterName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list machines: %w", err)
+	}
+
+	machinesByDeployment, controlPlaneMachines := groupMachines(machineList)
+
 	// Get MachineDeployments
-	machineDeployments, err := getMachineDeployments(ctx, client, clusterName, logger)
+	machineDeployments, err := getMachineDeployments(ctx, client, clusterName, machinesByDeployment)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get machine deployments: %w", err)
 	}
 
+	// Get control plane
+	controlPlane, err := getControlPlane(ctx, client, clusterName, controlPlaneMachines, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get control plane: %w", err)
+	}
+
 	return &ClusterDetail{
 		ClusterInfo:        *clusterInfo,
+		ControlPlane:       controlPlane,
 		MachineDeployments: machineDeployments,
+	}, nil
+}
+
+// getControlPlane retrieves the TalosControlPlane for the cluster and its machines.
+func getControlPlane(
+	ctx context.Context,
+	client ctrlclient.Client,
+	clusterName string,
+	machines []MachineDetail,
+	logger *zap.Logger,
+) (*ControlPlaneDetail, error) {
+	cpList := &taloscontrolplanev1.TalosControlPlaneList{}
+
+	err := client.List(ctx, cpList, ctrlclient.InNamespace(DefaultNamespace), ctrlclient.MatchingLabels{
+		ClusterNameLabel: clusterName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list control planes: %w", err)
+	}
+
+	if len(cpList.Items) == 0 {
+		logger.Debug("No control plane found for cluster", zap.String("cluster", clusterName))
+
+		if len(machines) == 0 {
+			return nil, nil //nolint:nilnil
+		}
+
+		return &ControlPlaneDetail{
+			Name:     clusterName,
+			Phase:    UnknownVersion,
+			Machines: machines,
+		}, nil
+	}
+
+	controlPlane := &cpList.Items[0]
+
+	phase := UnknownVersion
+
+	switch {
+	case controlPlane.Status.Ready:
+		phase = MachinePhaseRunning
+	case controlPlane.Status.Initialized:
+		phase = MachinePhaseProvisioning
+	}
+
+	replicas := controlPlane.Status.Replicas
+
+	return &ControlPlaneDetail{
+		Name:     controlPlane.Name,
+		Phase:    phase,
+		Replicas: &replicas,
+		Machines: machines,
 	}, nil
 }
 
@@ -83,7 +164,7 @@ func getMachineDeployments(
 	ctx context.Context,
 	client ctrlclient.Client,
 	clusterName string,
-	logger *zap.Logger,
+	machinesByDeployment map[string][]MachineDetail,
 ) ([]MachineDeploymentDetail, error) {
 	mdList := &clusterv1.MachineDeploymentList{}
 
@@ -92,14 +173,6 @@ func getMachineDeployments(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list machine deployments: %w", err)
-	}
-
-	// Fetch all machines once to avoid N+1 queries
-	machinesByDeployment, err := getMachinesGroupedByDeployment(ctx, client)
-	if err != nil {
-		logger.Warn("Failed to get machines", zap.Error(err))
-		// Continue with empty machines rather than failing
-		machinesByDeployment = make(map[string][]MachineDetail)
 	}
 
 	var result []MachineDeploymentDetail
@@ -142,60 +215,57 @@ func getMachineDeployments(
 	return result, nil
 }
 
-// getMachinesGroupedByDeployment fetches all machines once and groups them by deployment.
-// This avoids N+1 queries when fetching machines for multiple deployments.
-func getMachinesGroupedByDeployment(
-	ctx context.Context,
-	client ctrlclient.Client,
-) (map[string][]MachineDetail, error) {
-	machineList := &clusterv1.MachineList{}
+// groupMachines splits the machine list into per-MachineDeployment groups and a control plane group.
+func groupMachines(machineList *clusterv1.MachineList) (map[string][]MachineDetail, []MachineDetail) {
+	byDeployment := make(map[string][]MachineDetail)
 
-	err := client.List(ctx, machineList, ctrlclient.InNamespace(DefaultNamespace))
-	if err != nil {
-		return nil, fmt.Errorf("failed to list machines: %w", err)
-	}
-
-	// Group machines by their owning MachineDeployment
-	result := make(map[string][]MachineDetail)
+	var controlPlane []MachineDetail
 
 	for i := range machineList.Items {
 		machine := &machineList.Items[i]
+		detail := machineToDetail(machine)
 
-		// Find which deployment this machine belongs to
+		if _, isControlPlane := machine.Labels[clusterv1.MachineControlPlaneLabel]; isControlPlane {
+			controlPlane = append(controlPlane, detail)
+
+			continue
+		}
+
 		deploymentName := getDeploymentNameFromMachine(machine)
 		if deploymentName == "" {
 			continue
 		}
 
-		nodeName := UnknownVersion
-		if machine.Status.NodeRef != nil {
-			nodeName = machine.Status.NodeRef.Name
-		}
-
-		kubernetesVersion := UnknownVersion
-		if machine.Spec.Version != nil {
-			kubernetesVersion = *machine.Spec.Version
-		}
-
-		phase := machine.Status.Phase
-		if phase == "" {
-			phase = UnknownVersion
-		}
-
-		creationTime := machine.CreationTimestamp.Format("2006-01-02 15:04:05")
-
-		detail := MachineDetail{
-			Name:              machine.Name,
-			NodeName:          nodeName,
-			CreationTime:      creationTime,
-			Phase:             phase,
-			KubernetesVersion: kubernetesVersion,
-		}
-
-		result[deploymentName] = append(result[deploymentName], detail)
+		byDeployment[deploymentName] = append(byDeployment[deploymentName], detail)
 	}
 
-	return result, nil
+	return byDeployment, controlPlane
+}
+
+// machineToDetail converts a CAPI Machine into a UI MachineDetail.
+func machineToDetail(machine *clusterv1.Machine) MachineDetail {
+	nodeName := UnknownVersion
+	if machine.Status.NodeRef != nil {
+		nodeName = machine.Status.NodeRef.Name
+	}
+
+	kubernetesVersion := UnknownVersion
+	if machine.Spec.Version != nil {
+		kubernetesVersion = *machine.Spec.Version
+	}
+
+	phase := machine.Status.Phase
+	if phase == "" {
+		phase = UnknownVersion
+	}
+
+	return MachineDetail{
+		Name:              machine.Name,
+		NodeName:          nodeName,
+		CreationTime:      machine.CreationTimestamp.Format("2006-01-02 15:04:05"),
+		Phase:             phase,
+		KubernetesVersion: kubernetesVersion,
+	}
 }
 
 // getDeploymentNameFromMachine extracts the deployment name from a machine's owner references.

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -7,9 +7,18 @@ import (
 
 	taloscontrolplanev1 "github.com/siderolabs/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	clientgoclientset "k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Machine health status values for the UI health circle.
+const (
+	MachineHealthHealthy     = "Healthy"
+	MachineHealthUnhealthy   = "Unhealthy"
+	MachineHealthCheckFailed = "CheckFailed"
+	MachineHealthUnknown     = "Unknown"
 )
 
 // ClusterDetail holds detailed information about a cluster.
@@ -45,6 +54,8 @@ type MachineDetail struct {
 	CreationTime      string
 	Phase             string
 	KubernetesVersion string
+	Health            string
+	HealthReason      string
 }
 
 // GetClusterDetail retrieves detailed information about a specific cluster.
@@ -259,13 +270,37 @@ func machineToDetail(machine *clusterv1.Machine) MachineDetail {
 		phase = UnknownVersion
 	}
 
+	health, healthReason := machineHealthFromConditions(machine)
+
 	return MachineDetail{
 		Name:              machine.Name,
 		NodeName:          nodeName,
 		CreationTime:      machine.CreationTimestamp.Format("2006-01-02 15:04:05"),
 		Phase:             phase,
 		KubernetesVersion: kubernetesVersion,
+		Health:            health,
+		HealthReason:      healthReason,
 	}
+}
+
+// machineHealthFromConditions maps the HealthCheckSucceeded condition into a UI health state.
+func machineHealthFromConditions(machine *clusterv1.Machine) (string, string) {
+	for _, cond := range machine.Status.Conditions {
+		if cond.Type != clusterv1.MachineHealthCheckSucceededCondition {
+			continue
+		}
+
+		switch cond.Status {
+		case corev1.ConditionTrue:
+			return MachineHealthHealthy, ""
+		case corev1.ConditionFalse:
+			return MachineHealthUnhealthy, cond.Message
+		case corev1.ConditionUnknown:
+			return MachineHealthCheckFailed, cond.Message
+		}
+	}
+
+	return MachineHealthUnknown, ""
 }
 
 // getDeploymentNameFromMachine extracts the deployment name from a machine's owner references.

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -31,20 +31,22 @@ type ClusterDetail struct {
 
 // ControlPlaneDetail holds information about a control plane.
 type ControlPlaneDetail struct {
-	Name     string
-	Phase    string
-	Replicas *int32
-	Machines []MachineDetail
+	Name            string
+	Phase           string
+	Replicas        *int32
+	HealthyMachines int
+	Machines        []MachineDetail
 }
 
 // MachineDeploymentDetail holds information about a MachineDeployment.
 type MachineDeploymentDetail struct {
-	Name     string
-	Phase    string
-	Replicas *int32
-	MinSize  *int32
-	MaxSize  *int32
-	Machines []MachineDetail
+	Name            string
+	Phase           string
+	Replicas        *int32
+	MinSize         *int32
+	MaxSize         *int32
+	HealthyMachines int
+	Machines        []MachineDetail
 }
 
 // MachineDetail holds information about a Machine.
@@ -149,9 +151,10 @@ func getControlPlane(
 		}
 
 		return &ControlPlaneDetail{
-			Name:     clusterName,
-			Phase:    UnknownVersion,
-			Machines: machines,
+			Name:            clusterName,
+			Phase:           UnknownVersion,
+			HealthyMachines: countHealthyMachines(machines),
+			Machines:        machines,
 		}, nil
 	}
 
@@ -169,11 +172,25 @@ func getControlPlane(
 	replicas := controlPlane.Status.Replicas
 
 	return &ControlPlaneDetail{
-		Name:     controlPlane.Name,
-		Phase:    phase,
-		Replicas: &replicas,
-		Machines: machines,
+		Name:            controlPlane.Name,
+		Phase:           phase,
+		Replicas:        &replicas,
+		HealthyMachines: countHealthyMachines(machines),
+		Machines:        machines,
 	}, nil
+}
+
+// countHealthyMachines returns the number of machines with Health == Healthy.
+func countHealthyMachines(machines []MachineDetail) int {
+	count := 0
+
+	for _, machine := range machines {
+		if machine.Health == MachineHealthHealthy {
+			count++
+		}
+	}
+
+	return count
 }
 
 // getMachineDeployments retrieves all MachineDeployments for a cluster.
@@ -218,12 +235,13 @@ func getMachineDeployments(
 		replicas := deployment.Status.Replicas
 
 		detail := MachineDeploymentDetail{
-			Name:     deployment.Name,
-			Phase:    phase,
-			Replicas: &replicas,
-			MinSize:  minSize,
-			MaxSize:  maxSize,
-			Machines: machines,
+			Name:            deployment.Name,
+			Phase:           phase,
+			Replicas:        &replicas,
+			MinSize:         minSize,
+			MaxSize:         maxSize,
+			HealthyMachines: countHealthyMachines(machines),
+			Machines:        machines,
 		}
 
 		result = append(result, detail)

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	taloscontrolplanev1 "github.com/siderolabs/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	"go.uber.org/zap"
@@ -54,6 +55,7 @@ type MachineDetail struct {
 	Name              string
 	NodeName          string
 	CreationTime      string
+	Age               string
 	Phase             string
 	KubernetesVersion string
 	Health            string
@@ -297,7 +299,8 @@ func machineToDetail(machine *clusterv1.Machine) MachineDetail {
 	return MachineDetail{
 		Name:              machine.Name,
 		NodeName:          nodeName,
-		CreationTime:      machine.CreationTimestamp.Format("2006-01-02 15:04:05"),
+		CreationTime:      machine.CreationTimestamp.Format(time.RFC3339),
+		Age:               FormatAge(machine.CreationTimestamp.Time),
 		Phase:             phase,
 		KubernetesVersion: kubernetesVersion,
 		Health:            machineHealthFromConditions(machine),

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -98,13 +98,19 @@ func GetClusterDetail(
 	}
 
 	// Fetch all machines for the cluster once and group them.
+	// Degrade gracefully on list failure: log and render with no machines rather than fail the page.
 	machineList := &clusterv1.MachineList{}
 
 	err = client.List(ctx, machineList, ctrlclient.InNamespace(DefaultNamespace), ctrlclient.MatchingLabels{
 		ClusterNameLabel: clusterName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list machines: %w", err)
+		logger.Warn("Failed to list machines",
+			zap.String("cluster", clusterName),
+			zap.Error(err),
+		)
+
+		machineList = &clusterv1.MachineList{}
 	}
 
 	machinesByDeployment, controlPlaneMachines := groupMachines(machineList)

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -55,7 +55,13 @@ type MachineDetail struct {
 	Phase             string
 	KubernetesVersion string
 	Health            string
-	HealthReason      string
+	Conditions        []MachineConditionDetail
+}
+
+// MachineConditionDetail holds a single condition for UI display.
+type MachineConditionDetail struct {
+	Type   string
+	Status string
 }
 
 // GetClusterDetail retrieves detailed information about a specific cluster.
@@ -270,25 +276,68 @@ func machineToDetail(machine *clusterv1.Machine) MachineDetail {
 		phase = UnknownVersion
 	}
 
-	health, healthReason := machineHealthFromConditions(machine)
-
 	return MachineDetail{
 		Name:              machine.Name,
 		NodeName:          nodeName,
 		CreationTime:      machine.CreationTimestamp.Format("2006-01-02 15:04:05"),
 		Phase:             phase,
 		KubernetesVersion: kubernetesVersion,
-		Health:            health,
-		HealthReason:      healthReason,
+		Health:            machineHealthFromConditions(machine),
+		Conditions:        extractDisplayConditions(machine),
 	}
 }
 
-// healthSummary aggregates the relevant CAPI conditions for a machine.
+// displayConditionTypes returns the condition types surfaced in the UI tooltip,
+// in display order.
+func displayConditionTypes() []clusterv1.ConditionType {
+	return []clusterv1.ConditionType{
+		clusterv1.ReadyCondition,
+		clusterv1.BootstrapReadyCondition,
+		clusterv1.InfrastructureReadyCondition,
+		clusterv1.MachineNodeHealthyCondition,
+		clusterv1.MachineHealthCheckSucceededCondition,
+	}
+}
+
+// extractDisplayConditions returns the configured display conditions for a machine,
+// preserving the order defined by displayConditionTypes. Missing conditions are
+// rendered with status "Unknown".
+func extractDisplayConditions(machine *clusterv1.Machine) []MachineConditionDetail {
+	found := make(map[clusterv1.ConditionType]*clusterv1.Condition, len(machine.Status.Conditions))
+
+	for i := range machine.Status.Conditions {
+		cond := &machine.Status.Conditions[i]
+		found[cond.Type] = cond
+	}
+
+	types := displayConditionTypes()
+	result := make([]MachineConditionDetail, 0, len(types))
+
+	for _, condType := range types {
+		cond, ok := found[condType]
+		if !ok {
+			result = append(result, MachineConditionDetail{
+				Type:   string(condType),
+				Status: string(corev1.ConditionUnknown),
+			})
+
+			continue
+		}
+
+		result = append(result, MachineConditionDetail{
+			Type:   string(condType),
+			Status: string(cond.Status),
+		})
+	}
+
+	return result
+}
+
+// healthSummary aggregates the relevant CAPI condition statuses for a machine.
 type healthSummary struct {
-	anyFalse   *clusterv1.Condition
-	anyUnknown *clusterv1.Condition
-	sawTrue    bool
-	sawAny     bool
+	hasFalse   bool
+	hasUnknown bool
+	hasTrue    bool
 }
 
 // summarizeHealthConditions walks machine conditions and aggregates those relevant to health.
@@ -306,19 +355,13 @@ func summarizeHealthConditions(machine *clusterv1.Machine) healthSummary {
 			continue
 		}
 
-		summary.sawAny = true
-
 		switch cond.Status {
 		case corev1.ConditionFalse:
-			if summary.anyFalse == nil {
-				summary.anyFalse = cond
-			}
+			summary.hasFalse = true
 		case corev1.ConditionUnknown:
-			if summary.anyUnknown == nil {
-				summary.anyUnknown = cond
-			}
+			summary.hasUnknown = true
 		case corev1.ConditionTrue:
-			summary.sawTrue = true
+			summary.hasTrue = true
 		}
 	}
 
@@ -329,19 +372,19 @@ func summarizeHealthConditions(machine *clusterv1.Machine) healthSummary {
 // Considers both HealthCheckSucceeded (set by MachineHealthCheck) and NodeHealthy
 // (reflects backing node Ready status). NodeHealthy is used because MHC may not be
 // configured, in which case HealthCheckSucceeded is absent.
-func machineHealthFromConditions(machine *clusterv1.Machine) (string, string) {
+func machineHealthFromConditions(machine *clusterv1.Machine) string {
 	summary := summarizeHealthConditions(machine)
 
 	switch {
-	case summary.anyFalse != nil:
-		return MachineHealthUnhealthy, summary.anyFalse.Message
-	case summary.anyUnknown != nil:
-		return MachineHealthCheckFailed, summary.anyUnknown.Message
-	case summary.sawTrue:
-		return MachineHealthHealthy, ""
+	case summary.hasFalse:
+		return MachineHealthUnhealthy
+	case summary.hasUnknown:
+		return MachineHealthCheckFailed
+	case summary.hasTrue:
+		return MachineHealthHealthy
 	}
 
-	return MachineHealthUnknown, ""
+	return MachineHealthUnknown
 }
 
 // getDeploymentNameFromMachine extracts the deployment name from a machine's owner references.

--- a/pkg/ui/api/cluster_detail.go
+++ b/pkg/ui/api/cluster_detail.go
@@ -283,21 +283,62 @@ func machineToDetail(machine *clusterv1.Machine) MachineDetail {
 	}
 }
 
-// machineHealthFromConditions maps the HealthCheckSucceeded condition into a UI health state.
-func machineHealthFromConditions(machine *clusterv1.Machine) (string, string) {
-	for _, cond := range machine.Status.Conditions {
-		if cond.Type != clusterv1.MachineHealthCheckSucceededCondition {
+// healthSummary aggregates the relevant CAPI conditions for a machine.
+type healthSummary struct {
+	anyFalse   *clusterv1.Condition
+	anyUnknown *clusterv1.Condition
+	sawTrue    bool
+	sawAny     bool
+}
+
+// summarizeHealthConditions walks machine conditions and aggregates those relevant to health.
+func summarizeHealthConditions(machine *clusterv1.Machine) healthSummary {
+	relevant := map[clusterv1.ConditionType]bool{
+		clusterv1.MachineHealthCheckSucceededCondition: true,
+		clusterv1.MachineNodeHealthyCondition:          true,
+	}
+
+	var summary healthSummary
+
+	for i := range machine.Status.Conditions {
+		cond := &machine.Status.Conditions[i]
+		if !relevant[cond.Type] {
 			continue
 		}
 
+		summary.sawAny = true
+
 		switch cond.Status {
-		case corev1.ConditionTrue:
-			return MachineHealthHealthy, ""
 		case corev1.ConditionFalse:
-			return MachineHealthUnhealthy, cond.Message
+			if summary.anyFalse == nil {
+				summary.anyFalse = cond
+			}
 		case corev1.ConditionUnknown:
-			return MachineHealthCheckFailed, cond.Message
+			if summary.anyUnknown == nil {
+				summary.anyUnknown = cond
+			}
+		case corev1.ConditionTrue:
+			summary.sawTrue = true
 		}
+	}
+
+	return summary
+}
+
+// machineHealthFromConditions derives a UI health state from CAPI conditions.
+// Considers both HealthCheckSucceeded (set by MachineHealthCheck) and NodeHealthy
+// (reflects backing node Ready status). NodeHealthy is used because MHC may not be
+// configured, in which case HealthCheckSucceeded is absent.
+func machineHealthFromConditions(machine *clusterv1.Machine) (string, string) {
+	summary := summarizeHealthConditions(machine)
+
+	switch {
+	case summary.anyFalse != nil:
+		return MachineHealthUnhealthy, summary.anyFalse.Message
+	case summary.anyUnknown != nil:
+		return MachineHealthCheckFailed, summary.anyUnknown.Message
+	case summary.sawTrue:
+		return MachineHealthHealthy, ""
 	}
 
 	return MachineHealthUnknown, ""

--- a/pkg/ui/router.go
+++ b/pkg/ui/router.go
@@ -591,6 +591,7 @@ func loadTemplates() map[string]*template.Template {
 		"templates/components/icon_chevron.html",
 		"templates/components/health_tooltip.html",
 		"templates/components/health_indicator.js.html",
+		"templates/components/machine_health.html",
 	}
 
 	return map[string]*template.Template{

--- a/pkg/ui/router.go
+++ b/pkg/ui/router.go
@@ -416,7 +416,6 @@ func buildClusterDetailData(
 	clusterDetail *api.ClusterDetail,
 	kubeconfigContent string,
 ) map[string]any {
-	// Calculate total machines and check if any deployment has autoscaler
 	totalMachines := 0
 	hasAutoscaler := false
 
@@ -592,6 +591,7 @@ func loadTemplates() map[string]*template.Template {
 		"templates/components/health_tooltip.html",
 		"templates/components/health_indicator.js.html",
 		"templates/components/machine_health.html",
+		"templates/components/group_health.html",
 	}
 
 	return map[string]*template.Template{

--- a/pkg/ui/router.go
+++ b/pkg/ui/router.go
@@ -420,6 +420,10 @@ func buildClusterDetailData(
 	totalMachines := 0
 	hasAutoscaler := false
 
+	if clusterDetail.ControlPlane != nil {
+		totalMachines += len(clusterDetail.ControlPlane.Machines)
+	}
+
 	for _, deployment := range clusterDetail.MachineDeployments {
 		totalMachines += len(deployment.Machines)
 

--- a/pkg/ui/router.go
+++ b/pkg/ui/router.go
@@ -51,8 +51,9 @@ var templatesFS embed.FS
 const (
 	htmxRequestHeader = "Hx-Request"
 	htmxTrue          = "true"
-	pageApp           = "app.html"
-	pageClusterDetail = "cluster_detail.html"
+	pageApp             = "app.html"
+	pageClusterDetail   = "cluster_detail.html"
+	pageClusterNotFound = "cluster_not_found.html"
 )
 
 // ErrTemplateNotFound is returned when a template is not found.
@@ -373,9 +374,8 @@ func (r *Router) handleClusterDetail(writer http.ResponseWriter, req *http.Reque
 	// Get cluster detail
 	clusterDetail, err := api.GetClusterDetail(ctx, client, kubeClient, clusterName, r.logger)
 	if err != nil {
-		// Return 404 for cluster not found, 500 for other errors
 		if errors.Is(err, api.ErrClusterNotFound) {
-			http.Error(writer, fmt.Sprintf("Cluster %s not found", clusterName), http.StatusNotFound)
+			r.renderClusterNotFound(writer, req, clusterName)
 
 			return
 		}
@@ -407,6 +407,23 @@ func (r *Router) handleClusterDetail(writer http.ResponseWriter, req *http.Reque
 	if err != nil {
 		r.logger.Error("failed to render cluster detail page", zap.Error(err))
 		http.Error(writer, "Failed to render page", http.StatusInternalServerError)
+	}
+}
+
+// renderClusterNotFound renders a friendly 404 page when a cluster cannot be found,
+// providing a link back to the dashboard.
+func (r *Router) renderClusterNotFound(writer http.ResponseWriter, req *http.Request, clusterName string) {
+	writer.WriteHeader(http.StatusNotFound)
+
+	data := map[string]any{
+		"Title":       "Cluster: " + clusterName,
+		"ClusterName": clusterName,
+		"Version":     getKommodityVersion(),
+	}
+
+	err := r.renderPageOrContent(writer, req, pageClusterNotFound, data)
+	if err != nil {
+		r.logger.Error("failed to render cluster not found page", zap.Error(err))
 	}
 }
 
@@ -595,8 +612,9 @@ func loadTemplates() map[string]*template.Template {
 	}
 
 	return map[string]*template.Template{
-		pageApp:           mustParsePage(shared, "templates/app.html"),
-		pageClusterDetail: mustParsePage(shared, "templates/cluster_detail.html"),
+		pageApp:             mustParsePage(shared, "templates/app.html"),
+		pageClusterDetail:   mustParsePage(shared, "templates/cluster_detail.html"),
+		pageClusterNotFound: mustParsePage(shared, "templates/cluster_not_found.html"),
 	}
 }
 

--- a/pkg/ui/templates/app.html
+++ b/pkg/ui/templates/app.html
@@ -14,7 +14,7 @@
                 {{end}}
             </div>
             <div>
-                <h1 class="text-4xl font-bold mb-2">Kommodity UI</h1>
+                <h1 class="text-4xl font-bold mb-2">Kommodity</h1>
                 <p class="text-xl text-gray-400">A single binary to power the sovereign backbone of your digital infrastructure.</p>
             </div>
         </div>

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -239,6 +239,33 @@
 {{template "health_indicator.js.html"}}
 
 <script>
+// Persist expand state per cluster across reloads
+const __expandStorageKey = 'kommodity:expanded:{{.ClusterName}}';
+
+function __getExpanded() {
+    try {
+        return new Set(JSON.parse(localStorage.getItem(__expandStorageKey) || '[]'));
+    } catch (e) {
+        return new Set();
+    }
+}
+
+function __saveExpanded(set) {
+    localStorage.setItem(__expandStorageKey, JSON.stringify(Array.from(set)));
+}
+
+function __expandRow(deploymentName) {
+    const machineRow = document.querySelector('.machine-row[data-deployment="' + deploymentName + '"]');
+    if (!machineRow) return;
+    machineRow.classList.remove('hidden');
+
+    const btn = document.querySelector('.deployment-toggle[data-deployment="' + deploymentName + '"]');
+    if (btn) {
+        const chevron = btn.closest('tr').querySelector('.deployment-toggle div');
+        if (chevron) chevron.classList.add('rotate-90');
+    }
+}
+
 // Toggle machine rows
 document.querySelectorAll('.deployment-toggle').forEach(function(btn) {
     btn.addEventListener('click', function() {
@@ -252,8 +279,21 @@ document.querySelectorAll('.deployment-toggle').forEach(function(btn) {
             if (chevron) {
                 chevron.classList.toggle('rotate-90');
             }
+
+            const expanded = __getExpanded();
+            if (machineRow.classList.contains('hidden')) {
+                expanded.delete(deploymentName);
+            } else {
+                expanded.add(deploymentName);
+            }
+            __saveExpanded(expanded);
         }
     });
+});
+
+// Restore expanded rows on load
+document.addEventListener('DOMContentLoaded', function() {
+    __getExpanded().forEach(__expandRow);
 });
 
 // Sort machine rows by creation time

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -99,7 +99,7 @@
                                             <th class="py-2 px-4 font-semibold text-gray-500">Kubernetes Version</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">
                                                 <button type="button" class="sort-creation-time cursor-pointer bg-transparent border-0 p-0 focus:outline-none hover:text-gray-300 transition-colors" data-deployment="cp-{{.Name}}">
-                                                    Creation Time <span class="sort-indicator">↕</span>
+                                                    Age <span class="sort-indicator">↕</span>
                                                 </button>
                                             </th>
                                         </tr>
@@ -116,7 +116,7 @@
                                             <td class="py-2 px-4">{{.Name}}</td>
                                             <td class="py-2 px-4">{{.NodeName}}</td>
                                             <td class="py-2 px-4">{{.KubernetesVersion}}</td>
-                                            <td class="py-2 px-4">{{.CreationTime}}</td>
+                                            <td class="py-2 px-4" data-creation-time="{{.CreationTime}}">{{.Age}}</td>
                                         </tr>
                                         {{end}}
                                     </tbody>
@@ -205,7 +205,7 @@
                                             <th class="py-2 px-4 font-semibold text-gray-500">Kubernetes Version</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">
                                                 <button type="button" class="sort-creation-time cursor-pointer bg-transparent border-0 p-0 focus:outline-none hover:text-gray-300 transition-colors" data-deployment="{{.Name}}">
-                                                    Creation Time <span class="sort-indicator">↕</span>
+                                                    Age <span class="sort-indicator">↕</span>
                                                 </button>
                                             </th>
                                         </tr>
@@ -222,7 +222,7 @@
                                             <td class="py-2 px-4">{{.Name}}</td>
                                             <td class="py-2 px-4">{{.NodeName}}</td>
                                             <td class="py-2 px-4">{{.KubernetesVersion}}</td>
-                                            <td class="py-2 px-4">{{.CreationTime}}</td>
+                                            <td class="py-2 px-4" data-creation-time="{{.CreationTime}}">{{.Age}}</td>
                                         </tr>
                                         {{end}}
                                     </tbody>
@@ -318,16 +318,16 @@ document.querySelectorAll('.sort-creation-time').forEach(function(btn) {
             sortState = 'desc';
             indicator.textContent = '↓';
             rows.sort(function(a, b) {
-                const timeA = a.cells[5].textContent;
-                const timeB = b.cells[5].textContent;
+                const timeA = a.cells[5].getAttribute('data-creation-time') || '';
+                const timeB = b.cells[5].getAttribute('data-creation-time') || '';
                 return timeB.localeCompare(timeA);
             });
         } else {
             sortState = 'asc';
             indicator.textContent = '↑';
             rows.sort(function(a, b) {
-                const timeA = a.cells[5].textContent;
-                const timeB = b.cells[5].textContent;
+                const timeA = a.cells[5].getAttribute('data-creation-time') || '';
+                const timeB = b.cells[5].getAttribute('data-creation-time') || '';
                 return timeA.localeCompare(timeB);
             });
         }

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -51,10 +51,10 @@
                     <thead class="text-left border-b border-gray-800">
                         <tr>
                             <th class="pb-3 font-semibold text-gray-400 w-8"></th>
-                            <th class="pb-3 font-semibold text-gray-400">Name</th>
-                            <th class="pb-3 font-semibold text-gray-400">Phase</th>
+                            <th class="pb-3 font-semibold text-gray-400 w-96">Name</th>
+                            <th class="pb-3 font-semibold text-gray-400 w-32">Phase</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Replicas</th>
-                            <th class="pb-3 pl-4 font-semibold text-gray-400">Healthy</th>
+                            <th class="pb-3 pl-4 font-semibold text-gray-400 w-32">Healthy</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -141,12 +141,12 @@
                     <thead class="text-left border-b border-gray-800">
                         <tr>
                             <th class="pb-3 font-semibold text-gray-400 w-8"></th>
-                            <th class="pb-3 font-semibold text-gray-400">Name</th>
-                            <th class="pb-3 font-semibold text-gray-400">Phase</th>
+                            <th class="pb-3 font-semibold text-gray-400 w-96">Name</th>
+                            <th class="pb-3 font-semibold text-gray-400 w-32">Phase</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Min</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Current</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Max</th>
-                            <th class="pb-3 pl-4 font-semibold text-gray-400">Healthy</th>
+                            <th class="pb-3 pl-4 font-semibold text-gray-400 w-32">Healthy</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -44,7 +44,7 @@
         <!-- Control Plane Table -->
         {{if .Cluster.ControlPlane}}
         <div class="rounded-sm border border-gray-800 bg-gray-900 p-6">
-            <h2 class="text-xl font-semibold mb-4">Control Plane</h2>
+            <h2 class="text-xl font-semibold mb-4">Control Planes</h2>
 
             <div class="overflow-x-auto">
                 <table class="w-full text-sm">
@@ -104,7 +104,7 @@
                                         {{range .Machines}}
                                         <tr class="border-b border-gray-700 last:border-0">
                                             <td class="py-2 px-6">
-                                                {{template "machine_health.html" (dict "Health" .Health "Reason" .HealthReason)}}
+                                                {{template "machine_health.html" (dict "Health" .Health "Conditions" .Conditions)}}
                                             </td>
                                             <td class="py-2 px-4">
                                                 <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>
@@ -206,7 +206,7 @@
                                         {{range .Machines}}
                                         <tr class="border-b border-gray-700 last:border-0">
                                             <td class="py-2 px-6">
-                                                {{template "machine_health.html" (dict "Health" .Health "Reason" .HealthReason)}}
+                                                {{template "machine_health.html" (dict "Health" .Health "Conditions" .Conditions)}}
                                             </td>
                                             <td class="py-2 px-4">
                                                 <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -61,14 +61,14 @@
                         {{with .Cluster.ControlPlane}}
                         <tr class="border-b border-gray-800">
                             <td class="py-4 pl-4">
-                                <button type="button" class="deployment-toggle inline-flex items-center cursor-pointer bg-transparent border-0 p-0 focus:outline-none" data-deployment="cp-{{.Name}}">
+                                <button type="button" class="deployment-toggle inline-flex items-center cursor-pointer bg-transparent border-0 p-0 focus:outline-none" data-deployment="cp-{{.Name}}" aria-expanded="false" aria-controls="machines-cp-{{.Name}}" aria-label="Toggle machines for {{.Name}}">
                                     <div class="rotate-0 transition-transform duration-200">
                                         {{template "icon_chevron.html"}}
                                     </div>
                                 </button>
                             </td>
                             <td class="py-4">
-                                <button type="button" class="deployment-toggle cursor-pointer bg-transparent border-0 p-0 focus:outline-none text-left font-medium" data-deployment="cp-{{.Name}}">
+                                <button type="button" class="deployment-toggle cursor-pointer bg-transparent border-0 p-0 focus:outline-none text-left font-medium" data-deployment="cp-{{.Name}}" aria-expanded="false" aria-controls="machines-cp-{{.Name}}">
                                     {{.Name}}
                                 </button>
                             </td>
@@ -87,7 +87,7 @@
                             </td>
                         </tr>
                         {{if .Machines}}
-                        <tr class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="cp-{{.Name}}">
+                        <tr id="machines-cp-{{.Name}}" class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="cp-{{.Name}}">
                             <td colspan="5" class="p-0">
                                 <table class="w-full text-xs">
                                     <thead class="text-left border-b border-gray-700">
@@ -108,7 +108,7 @@
                                         {{range .Machines}}
                                         <tr class="border-b border-gray-700 last:border-0">
                                             <td class="py-2 px-6">
-                                                {{template "machine_health.html" (dict "Health" .Health "Conditions" .Conditions)}}
+                                                {{template "machine_health.html" (dict "Health" .Health "Conditions" .Conditions "Name" .Name)}}
                                             </td>
                                             <td class="py-2 px-4">
                                                 <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>
@@ -153,14 +153,14 @@
                         {{range .Cluster.MachineDeployments}}
                         <tr class="border-b border-gray-800">
                             <td class="py-4 pl-4">
-                                <button type="button" class="deployment-toggle inline-flex items-center cursor-pointer bg-transparent border-0 p-0 focus:outline-none" data-deployment="{{.Name}}">
+                                <button type="button" class="deployment-toggle inline-flex items-center cursor-pointer bg-transparent border-0 p-0 focus:outline-none" data-deployment="{{.Name}}" aria-expanded="false" aria-controls="machines-{{.Name}}" aria-label="Toggle machines for {{.Name}}">
                                     <div class="rotate-0 transition-transform duration-200">
                                         {{template "icon_chevron.html"}}
                                     </div>
                                 </button>
                             </td>
                             <td class="py-4">
-                                <button type="button" class="deployment-toggle cursor-pointer bg-transparent border-0 p-0 focus:outline-none text-left font-medium" data-deployment="{{.Name}}">
+                                <button type="button" class="deployment-toggle cursor-pointer bg-transparent border-0 p-0 focus:outline-none text-left font-medium" data-deployment="{{.Name}}" aria-expanded="false" aria-controls="machines-{{.Name}}">
                                     {{.Name}}
                                 </button>
                             </td>
@@ -193,7 +193,7 @@
                             </td>
                         </tr>
                         {{if .Machines}}
-                        <tr class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="{{.Name}}">
+                        <tr id="machines-{{.Name}}" class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="{{.Name}}">
                             <td colspan="7" class="p-0">
                                 <table class="w-full text-xs">
                                     <thead class="text-left border-b border-gray-700">
@@ -214,7 +214,7 @@
                                         {{range .Machines}}
                                         <tr class="border-b border-gray-700 last:border-0">
                                             <td class="py-2 px-6">
-                                                {{template "machine_health.html" (dict "Health" .Health "Conditions" .Conditions)}}
+                                                {{template "machine_health.html" (dict "Health" .Health "Conditions" .Conditions "Name" .Name)}}
                                             </td>
                                             <td class="py-2 px-4">
                                                 <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>
@@ -267,11 +267,12 @@ function __expandRow(deploymentName) {
     if (!machineRow) return;
     machineRow.classList.remove('hidden');
 
-    const btn = document.querySelector('.deployment-toggle[data-deployment="' + deploymentName + '"]');
-    if (btn) {
-        const chevron = btn.closest('tr').querySelector('.deployment-toggle div');
+    const btns = document.querySelectorAll('.deployment-toggle[data-deployment="' + deploymentName + '"]');
+    btns.forEach(function(b) {
+        b.setAttribute('aria-expanded', 'true');
+        const chevron = b.querySelector('div');
         if (chevron) chevron.classList.add('rotate-90');
-    }
+    });
 }
 
 // Toggle machine rows
@@ -288,11 +289,16 @@ document.querySelectorAll('.deployment-toggle').forEach(function(btn) {
                 chevron.classList.toggle('rotate-90');
             }
 
+            const isExpanded = !machineRow.classList.contains('hidden');
+            document.querySelectorAll('.deployment-toggle[data-deployment="' + deploymentName + '"]').forEach(function(b) {
+                b.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+            });
+
             const expanded = __getExpanded();
-            if (machineRow.classList.contains('hidden')) {
-                expanded.delete(deploymentName);
-            } else {
+            if (isExpanded) {
                 expanded.add(deploymentName);
+            } else {
+                expanded.delete(deploymentName);
             }
             __saveExpanded(expanded);
         }

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -41,6 +41,88 @@
             {{end}}
         </div>
 
+        <!-- Control Plane Table -->
+        {{if .Cluster.ControlPlane}}
+        <div class="rounded-sm border border-gray-800 bg-gray-900 p-6">
+            <h2 class="text-xl font-semibold mb-4">Control Plane</h2>
+
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead class="text-left border-b border-gray-800">
+                        <tr>
+                            <th class="pb-3 font-semibold text-gray-400 w-8"></th>
+                            <th class="pb-3 font-semibold text-gray-400">Name</th>
+                            <th class="pb-3 font-semibold text-gray-400">Phase</th>
+                            <th class="pb-3 pl-4 font-semibold text-gray-400">Replicas</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{with .Cluster.ControlPlane}}
+                        <tr class="border-b border-gray-800">
+                            <td class="py-4 pl-4">
+                                <button type="button" class="deployment-toggle inline-flex items-center cursor-pointer bg-transparent border-0 p-0 focus:outline-none" data-deployment="cp-{{.Name}}">
+                                    <div class="rotate-0 transition-transform duration-200">
+                                        {{template "icon_chevron.html"}}
+                                    </div>
+                                </button>
+                            </td>
+                            <td class="py-4">
+                                <button type="button" class="deployment-toggle cursor-pointer bg-transparent border-0 p-0 focus:outline-none text-left font-medium" data-deployment="cp-{{.Name}}">
+                                    {{.Name}}
+                                </button>
+                            </td>
+                            <td class="py-4">
+                                <code class="px-2 py-1 bg-gray-800 rounded text-xs">{{.Phase}}</code>
+                            </td>
+                            <td class="py-4 pl-4">
+                                {{if .Replicas}}
+                                <span class="text-accent">{{.Replicas}}</span>
+                                {{else}}
+                                <span class="text-accent">0</span>
+                                {{end}}
+                            </td>
+                        </tr>
+                        {{if .Machines}}
+                        <tr class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="cp-{{.Name}}">
+                            <td colspan="4" class="p-0">
+                                <table class="w-full text-xs">
+                                    <thead class="text-left border-b border-gray-700">
+                                        <tr>
+                                            <th class="py-2 px-6 font-semibold text-gray-500">Phase</th>
+                                            <th class="py-2 px-4 font-semibold text-gray-500">Name</th>
+                                            <th class="py-2 px-4 font-semibold text-gray-500">Node Name</th>
+                                            <th class="py-2 px-4 font-semibold text-gray-500">Kubernetes Version</th>
+                                            <th class="py-2 px-4 font-semibold text-gray-500">
+                                                <button type="button" class="sort-creation-time cursor-pointer bg-transparent border-0 p-0 focus:outline-none hover:text-gray-300 transition-colors" data-deployment="cp-{{.Name}}">
+                                                    Creation Time <span class="sort-indicator">↕</span>
+                                                </button>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {{range .Machines}}
+                                        <tr class="border-b border-gray-700 last:border-0">
+                                            <td class="py-2 px-6">
+                                                <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>
+                                            </td>
+                                            <td class="py-2 px-4">{{.Name}}</td>
+                                            <td class="py-2 px-4">{{.NodeName}}</td>
+                                            <td class="py-2 px-4">{{.KubernetesVersion}}</td>
+                                            <td class="py-2 px-4">{{.CreationTime}}</td>
+                                        </tr>
+                                        {{end}}
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        {{end}}
+                        {{end}}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {{end}}
+
         <!-- Machine Deployments Table -->
         <div class="rounded-sm border border-gray-800 bg-gray-900 p-6">
             <h2 class="text-xl font-semibold mb-4">Machine Deployments</h2>

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -15,7 +15,7 @@
             </div>
             <div>
                 <h1 class="text-4xl font-bold mb-2">{{.Cluster.Name}}</h1>
-                <p class="text-xl text-gray-400">Cluster details and machine deployments</p>
+                <p class="text-xl text-gray-400">Cluster details</p>
             </div>
         </div>
 

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -54,6 +54,7 @@
                             <th class="pb-3 font-semibold text-gray-400">Name</th>
                             <th class="pb-3 font-semibold text-gray-400">Phase</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Replicas</th>
+                            <th class="pb-3 pl-4 font-semibold text-gray-400">Healthy</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -81,10 +82,13 @@
                                 <span class="text-accent">0</span>
                                 {{end}}
                             </td>
+                            <td class="py-4 pl-4">
+                                {{template "group_health.html" (dict "Healthy" .HealthyMachines "Total" (len .Machines))}}
+                            </td>
                         </tr>
                         {{if .Machines}}
                         <tr class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="cp-{{.Name}}">
-                            <td colspan="4" class="p-0">
+                            <td colspan="5" class="p-0">
                                 <table class="w-full text-xs">
                                     <thead class="text-left border-b border-gray-700">
                                         <tr>
@@ -142,6 +146,7 @@
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Min</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Current</th>
                             <th class="pb-3 pl-4 font-semibold text-gray-400">Max</th>
+                            <th class="pb-3 pl-4 font-semibold text-gray-400">Healthy</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -183,10 +188,13 @@
                                 <span class="text-gray-500">—</span>
                                 {{end}}
                             </td>
+                            <td class="py-4 pl-4">
+                                {{template "group_health.html" (dict "Healthy" .HealthyMachines "Total" (len .Machines))}}
+                            </td>
                         </tr>
                         {{if .Machines}}
                         <tr class="machine-row hidden border-b border-gray-800 bg-gray-800/30" data-deployment="{{.Name}}">
-                            <td colspan="6" class="p-0">
+                            <td colspan="7" class="p-0">
                                 <table class="w-full text-xs">
                                     <thead class="text-left border-b border-gray-700">
                                         <tr>

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -88,7 +88,8 @@
                                 <table class="w-full text-xs">
                                     <thead class="text-left border-b border-gray-700">
                                         <tr>
-                                            <th class="py-2 px-6 font-semibold text-gray-500">Phase</th>
+                                            <th class="py-2 px-6 font-semibold text-gray-500">Health</th>
+                                            <th class="py-2 px-4 font-semibold text-gray-500">Phase</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">Name</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">Node Name</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">Kubernetes Version</th>
@@ -103,6 +104,9 @@
                                         {{range .Machines}}
                                         <tr class="border-b border-gray-700 last:border-0">
                                             <td class="py-2 px-6">
+                                                {{template "machine_health.html" (dict "Health" .Health "Reason" .HealthReason)}}
+                                            </td>
+                                            <td class="py-2 px-4">
                                                 <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>
                                             </td>
                                             <td class="py-2 px-4">{{.Name}}</td>
@@ -186,7 +190,8 @@
                                 <table class="w-full text-xs">
                                     <thead class="text-left border-b border-gray-700">
                                         <tr>
-                                            <th class="py-2 px-6 font-semibold text-gray-500">Phase</th>
+                                            <th class="py-2 px-6 font-semibold text-gray-500">Health</th>
+                                            <th class="py-2 px-4 font-semibold text-gray-500">Phase</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">Name</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">Node Name</th>
                                             <th class="py-2 px-4 font-semibold text-gray-500">Kubernetes Version</th>
@@ -201,6 +206,9 @@
                                         {{range .Machines}}
                                         <tr class="border-b border-gray-700 last:border-0">
                                             <td class="py-2 px-6">
+                                                {{template "machine_health.html" (dict "Health" .Health "Reason" .HealthReason)}}
+                                            </td>
+                                            <td class="py-2 px-4">
                                                 <code class="px-2 py-1 bg-gray-700 rounded">{{.Phase}}</code>
                                             </td>
                                             <td class="py-2 px-4">{{.Name}}</td>
@@ -262,16 +270,16 @@ document.querySelectorAll('.sort-creation-time').forEach(function(btn) {
             sortState = 'desc';
             indicator.textContent = '↓';
             rows.sort(function(a, b) {
-                const timeA = a.cells[4].textContent;
-                const timeB = b.cells[4].textContent;
+                const timeA = a.cells[5].textContent;
+                const timeB = b.cells[5].textContent;
                 return timeB.localeCompare(timeA);
             });
         } else {
             sortState = 'asc';
             indicator.textContent = '↑';
             rows.sort(function(a, b) {
-                const timeA = a.cells[4].textContent;
-                const timeB = b.cells[4].textContent;
+                const timeA = a.cells[5].textContent;
+                const timeB = b.cells[5].textContent;
                 return timeA.localeCompare(timeB);
             });
         }

--- a/pkg/ui/templates/cluster_not_found.html
+++ b/pkg/ui/templates/cluster_not_found.html
@@ -1,0 +1,35 @@
+{{define "content"}}
+<div data-page-title="Cluster: {{.ClusterName}}">
+    <div class="grid gap-4">
+        <!-- Hero Header -->
+        <div class="flex items-center gap-4">
+            <div class="flex flex-col items-center">
+                <a href="/ui" class="mb-2 cursor-pointer hover:opacity-80 transition-opacity">
+                    <img src="/ui/public/kommodity-logo.svg" alt="Kommodity Logo" class="h-16 w-16 object-contain" />
+                </a>
+                {{if ne .Version "development"}}
+                    <a href="https://github.com/kommodity-io/kommodity/releases/tag/{{.Version}}" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-500 hover:text-accent transition-colors">{{.Version}}</a>
+                {{else}}
+                    <span class="text-sm text-gray-500">{{.Version}}</span>
+                {{end}}
+            </div>
+            <div>
+                <h1 class="text-4xl font-bold mb-2">{{.ClusterName}}</h1>
+                <p class="text-xl text-gray-400">Cluster details</p>
+            </div>
+        </div>
+
+        <!-- Empty State -->
+        <div class="rounded-sm border border-gray-800 bg-gray-900 p-12 text-center">
+            <div class="text-5xl mb-4 text-gray-600">⊘</div>
+            <h2 class="text-2xl font-semibold mb-2">Cluster not found</h2>
+            <p class="text-gray-400 mb-6">
+                Cluster <code class="px-2 py-1 bg-gray-800 rounded text-sm">{{.ClusterName}}</code> no longer exists or was removed.
+            </p>
+            <a href="/ui" class="inline-flex items-center justify-center gap-2 rounded-sm text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent bg-accent text-gray-950 hover:bg-accent-glow hover:shadow-lg h-10 px-6">
+                ← Back to Dashboard
+            </a>
+        </div>
+    </div>
+</div>
+{{end}}

--- a/pkg/ui/templates/components/group_health.html
+++ b/pkg/ui/templates/components/group_health.html
@@ -1,0 +1,16 @@
+{{define "group_health.html"}}
+{{- $color := "text-gray-500" -}}
+{{- if eq .Total 0 -}}
+    {{- $color = "text-gray-500" -}}
+{{- else if eq .Healthy .Total -}}
+    {{- $color = "text-green-500" -}}
+{{- else if eq .Healthy 0 -}}
+    {{- $color = "text-red-500" -}}
+{{- else -}}
+    {{- $color = "text-yellow-500" -}}
+{{- end -}}
+<span class="inline-flex items-center gap-2">
+    <span class="{{$color}} text-base leading-none">●</span>
+    <span class="text-gray-300">{{.Healthy}}/{{.Total}}</span>
+</span>
+{{end}}

--- a/pkg/ui/templates/components/machine_health.html
+++ b/pkg/ui/templates/components/machine_health.html
@@ -11,8 +11,27 @@
     {{- $color = "text-yellow-500" -}}
     {{- $label = "Check failed" -}}
 {{- end -}}
-<span class="inline-flex items-center gap-2" title="{{$label}}{{if .Reason}}: {{.Reason}}{{end}}">
+<span class="machine-health relative inline-flex items-center gap-2" tabindex="0">
     <span class="{{$color}} text-base leading-none">●</span>
     <span class="text-gray-400">{{$label}}</span>
+    {{- if .Conditions }}
+    <div class="machine-health-tooltip invisible fixed z-50 w-80 rounded-sm border border-gray-700 bg-gray-900 p-3 shadow-lg text-xs pointer-events-none">
+        <div class="font-semibold text-gray-300 mb-2 border-b border-gray-700 pb-1">Conditions</div>
+        <ul class="space-y-1.5">
+            {{- range .Conditions }}
+            {{- $dot := "text-gray-500" -}}
+            {{- if eq .Status "True" -}}{{- $dot = "text-green-500" -}}{{- end -}}
+            {{- if eq .Status "False" -}}{{- $dot = "text-red-500" -}}{{- end -}}
+            {{- if eq .Status "Unknown" -}}{{- $dot = "text-yellow-500" -}}{{- end -}}
+            <li class="flex items-start gap-2">
+                <span class="{{$dot}} leading-none mt-0.5">●</span>
+                <div class="flex-1 min-w-0">
+                    <div class="text-gray-200">{{.Type}}<span class="text-gray-500"> · {{.Status}}</span></div>
+                </div>
+            </li>
+            {{- end }}
+        </ul>
+    </div>
+    {{- end }}
 </span>
 {{end}}

--- a/pkg/ui/templates/components/machine_health.html
+++ b/pkg/ui/templates/components/machine_health.html
@@ -11,11 +11,12 @@
     {{- $color = "text-yellow-500" -}}
     {{- $label = "Check failed" -}}
 {{- end -}}
-<span class="machine-health relative inline-flex items-center gap-2" tabindex="0">
-    <span class="{{$color}} text-base leading-none">●</span>
+{{- $tooltipID := printf "machine-conditions-%s" .Name -}}
+<span class="machine-health relative inline-flex items-center gap-2" tabindex="0"{{if .Conditions}} aria-describedby="{{$tooltipID}}"{{end}}>
+    <span class="{{$color}} text-base leading-none" aria-hidden="true">●</span>
     <span class="text-gray-400">{{$label}}</span>
     {{- if .Conditions }}
-    <div class="machine-health-tooltip invisible fixed z-50 w-80 rounded-sm border border-gray-700 bg-gray-900 p-3 shadow-lg text-xs pointer-events-none">
+    <div id="{{$tooltipID}}" role="tooltip" class="machine-health-tooltip invisible fixed z-50 w-80 rounded-sm border border-gray-700 bg-gray-900 p-3 shadow-lg text-xs pointer-events-none">
         <div class="font-semibold text-gray-300 mb-2 border-b border-gray-700 pb-1">Conditions</div>
         <ul class="space-y-1.5">
             {{- range .Conditions }}
@@ -24,7 +25,7 @@
             {{- if eq .Status "False" -}}{{- $dot = "text-red-500" -}}{{- end -}}
             {{- if eq .Status "Unknown" -}}{{- $dot = "text-yellow-500" -}}{{- end -}}
             <li class="flex items-start gap-2">
-                <span class="{{$dot}} leading-none mt-0.5">●</span>
+                <span class="{{$dot}} leading-none mt-0.5" aria-hidden="true">●</span>
                 <div class="flex-1 min-w-0">
                     <div class="text-gray-200">{{.Type}}<span class="text-gray-500"> · {{.Status}}</span></div>
                 </div>

--- a/pkg/ui/templates/components/machine_health.html
+++ b/pkg/ui/templates/components/machine_health.html
@@ -1,0 +1,18 @@
+{{define "machine_health.html"}}
+{{- $color := "text-gray-500" -}}
+{{- $label := "Unknown" -}}
+{{- if eq .Health "Healthy" -}}
+    {{- $color = "text-green-500" -}}
+    {{- $label = "Healthy" -}}
+{{- else if eq .Health "Unhealthy" -}}
+    {{- $color = "text-red-500" -}}
+    {{- $label = "Unhealthy" -}}
+{{- else if eq .Health "CheckFailed" -}}
+    {{- $color = "text-yellow-500" -}}
+    {{- $label = "Check failed" -}}
+{{- end -}}
+<span class="inline-flex items-center gap-2" title="{{$label}}{{if .Reason}}: {{.Reason}}{{end}}">
+    <span class="{{$color}} text-base leading-none">●</span>
+    <span class="text-gray-400">{{$label}}</span>
+</span>
+{{end}}

--- a/pkg/ui/templates/layout.html
+++ b/pkg/ui/templates/layout.html
@@ -167,6 +167,13 @@
             background: rgb(75 85 99);
         }
 
+        /* Machine health tooltip */
+        .machine-health:hover .machine-health-tooltip,
+        .machine-health:focus-within .machine-health-tooltip,
+        .machine-health:focus .machine-health-tooltip {
+            visibility: visible;
+        }
+
         /* Code Block Styling */
         .code-block {
             background-color: rgb(17 24 39);
@@ -239,6 +246,25 @@
 
         document.addEventListener('htmx:historyRestore', function() {
             hideLoading();
+        });
+
+        // Position machine-health tooltip on hover/focus (fixed positioning escapes overflow ancestors).
+        function positionMachineHealthTooltip(trigger) {
+            var tip = trigger.querySelector('.machine-health-tooltip');
+            if (!tip) return;
+            var rect = trigger.getBoundingClientRect();
+            tip.style.left = Math.max(8, rect.left) + 'px';
+            tip.style.top = (rect.bottom + 8) + 'px';
+        }
+
+        document.addEventListener('mouseover', function(e) {
+            var trigger = e.target.closest('.machine-health');
+            if (trigger) positionMachineHealthTooltip(trigger);
+        });
+
+        document.addEventListener('focusin', function(e) {
+            var trigger = e.target.closest('.machine-health');
+            if (trigger) positionMachineHealthTooltip(trigger);
         });
 
         // Utility functions


### PR DESCRIPTION
New features:

- Control plane machines shown
- Preserve tabs status on refresh (keep open if open)
- Machine status badge + more info on hover

<img width="331" height="196" alt="Screenshot 2026-06-17 at 08 43 13" src="https://github.com/user-attachments/assets/62ab760e-d663-4331-8afb-eb8d6a5e8582" />

- nodepool shows Machines ready / Total machines
- Handle gracefully when cluster is removed or non-existing

<img width="536" height="266" alt="Screenshot 2026-06-17 at 08 47 05" src="https://github.com/user-attachments/assets/4c244824-5870-4f51-8a6d-c5b8ce7f4b08" />

<img width="1361" height="981" alt="Screenshot 2026-06-17 at 08 44 52" src="https://github.com/user-attachments/assets/90bb4d82-0c0f-4e54-8fcf-059a70eea657" />

Signed-off-by: Paul Thuriot <pth@corti.ai>
