### PR TITLE
fix(argocd): disable server ingress by default in bootstrap initialExtraValues

### DIFF
--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -172,6 +172,9 @@ kommodity:
         configs:
           cm:
             admin.enabled: false
+        server:
+          ingress:
+            enabled: false
 
     # talos-cluster-proxy is an addon that deploys the talos-cluster-proxy pod, a component that runs on the cluster
     # and proxies requests coming from Kommodity (TalosControlPlaneReconciler) to the Talos nodes.


### PR DESCRIPTION
## Summary

Adds `server.ingress.enabled: false` to the argocd addon's `initialExtraValues` in `charts/kommodity-cluster/values.yaml`.

## Background

When Kommodity bootstraps ArgoCD, it runs a one-shot Helm install using the chart defined in `addons.argocd.chart`. The upstream `argo-cd` chart already defaults `server.ingress.enabled: false`, so this is a no-op for the default chart.

However, when a consumer overrides the chart (e.g. with a wrapper chart that changes the default to `enabled: true`), the bootstrap will render an `Ingress` resource with the placeholder hostname `argocd.example.com`. Since `upgrade.disable: true`, the addon is never reconciled again — these Ingresses become permanent orphans. External-dns then emits noisy warnings on every reconcile loop:

```
Ignoring changes to 'argocd.example.com' because a suitable Azure DNS zone was not found.
Ignoring changes to 'a-argocd.example.com' because a suitable Azure DNS zone was not found.
```

Explicitly setting `server.ingress.enabled: false` in `initialExtraValues` overrides any chart-level default and prevents the Ingress from being created during bootstrap regardless of which chart is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)