### PR TITLE
feat(chart): default Azure resourceGroup to release name

### DIFF
--- a/articles/azure-requirements.md
+++ b/articles/azure-requirements.md
@@ -295,7 +295,7 @@ kommodity:
       name: azure-cluster-identity        # AzureClusterIdentity created in §4.1
     config:
       subscriptionID: <subscription-id>
-      resourceGroup: <workload-rg>        # CAPZ creates this RG automatically
+      # resourceGroup: <workload-rg>     # optional; defaults to the release name
       location: westeurope
       talosImageResourceGroup: <image-rg> # RG holding the Talos managed image
 

--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.1
+version: 0.21.2
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -299,9 +299,10 @@ group (and, in BYO-VNet mode, its VNet — overlapping subnet CIDRs), corrupting
 both rather than failing fast.
 
 Convention: the Azure resource group is named after the cluster (== release
-name). This template enforces that convention so a copied-but-unedited values
-file is rejected at `helm install`/`template` time — before anything is
-provisioned, when it is trivially removable.
+name). When `resourceGroup` is omitted from values it defaults to the release
+name (see cluster.yaml). This template catches the case where it is set
+explicitly to a different value — a copied-but-unedited values file — and
+rejects it at `helm install`/`template` time, before anything is provisioned.
 
 (The CCM Secret collision is guarded independently on the management plane: the
 credential materializer refuses to take over a Secret owned by another cluster —

--- a/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
@@ -16,11 +16,8 @@ spec:
   {{- else }}
   {{- fail "missing required subscriptionID in kommodity.provider.config for Azure" -}}
   {{- end }}
-  {{- if dig "config" "resourceGroup" "" .Values.kommodity.provider }}
-  resourceGroup: {{ .Values.kommodity.provider.config.resourceGroup }}
-  {{- else }}
-  {{- fail "missing required resourceGroup in kommodity.provider.config for Azure" -}}
-  {{- end }}
+  {{- $rg := dig "config" "resourceGroup" "" .Values.kommodity.provider | default .Release.Name }}
+  resourceGroup: {{ $rg }}
   {{- if dig "config" "location" "" .Values.kommodity.provider }}
   location: {{ .Values.kommodity.provider.config.location }}
   {{- else }}
@@ -84,7 +81,7 @@ spec:
       {{- if and $hasVnet (dig "ipv4" "vnet" "resourceGroup" "" .Values.kommodity.network) }}
       resourceGroup: {{ .Values.kommodity.network.ipv4.vnet.resourceGroup }}
       {{- else }}
-      resourceGroup: {{ .Values.kommodity.provider.config.resourceGroup }}
+      resourceGroup: {{ $rg }}
       {{- end }}
       {{- if and $hasVnet (dig "ipv4" "vnet" "cidrBlocks" "" .Values.kommodity.network) }}
       cidrBlocks:
@@ -104,7 +101,7 @@ spec:
       {{- if and $hasVnet (dig "ipv4" "vnet" "resourceGroup" "" .Values.kommodity.network) }}
       resourceGroup: {{ .Values.kommodity.network.ipv4.vnet.resourceGroup }}
       {{- else }}
-      resourceGroup: {{ .Values.kommodity.provider.config.resourceGroup }}
+      resourceGroup: {{ $rg }}
       {{- end }}
       {{- if and $hasVnet (dig "ipv4" "vnet" "cidrBlocks" "" .Values.kommodity.network) }}
       cidrBlocks:

--- a/charts/kommodity-cluster/tests/azure_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_cluster_test.yaml
@@ -5,11 +5,8 @@ values:
 release:
   name: test-cluster
   namespace: default
-# The naming guard (kommodity.azure.validateNaming) requires the resource group to
-# equal the release name; the example values use a placeholder, so set it here for
-# the suite. Individual tests below exercise the guard's failure paths explicitly.
-set:
-  kommodity.provider.config.resourceGroup: test-cluster
+# resourceGroup defaults to the release name; no suite-level set needed.
+# Individual tests below exercise the guard's failure paths explicitly.
 templates:
   - templates/provider/azure/cluster.yaml
 tests:
@@ -104,12 +101,13 @@ tests:
       - failedTemplate:
           errorMessage: "missing required subscriptionID in kommodity.provider.config for Azure"
 
-  - it: should fail when resourceGroup is missing
+  - it: should default resourceGroup to the release name when not set
     set:
       kommodity.provider.config.resourceGroup: null
     asserts:
-      - failedTemplate:
-          errorMessage: "missing required resourceGroup in kommodity.provider.config for Azure"
+      - equal:
+          path: spec.resourceGroup
+          value: test-cluster
 
   - it: should fail when location is missing
     set:

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -5,10 +5,7 @@ values:
 release:
   name: test-cluster
   namespace: default
-# The naming guard (kommodity.azure.validateNaming) requires the resource group to
-# equal the release name; the example values use a placeholder, so set it here.
-set:
-  kommodity.provider.config.resourceGroup: test-cluster
+# resourceGroup defaults to the release name; no suite-level set needed.
 templates:
   - templates/*
 tests:

--- a/charts/kommodity-cluster/tests/capi_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/capi_provider_test.yaml
@@ -139,8 +139,6 @@ tests:
     values:
       - ../values.azure.yaml
     set:
-      # resourceGroup must equal the release name (kommodity.azure.validateNaming).
-      kommodity.provider.config.resourceGroup: test-cluster
       kommodity.network.ipv4.enabled: true
       kommodity.network.ipv4.public: true
       kommodity.network.ipv4.nodeCIDR: "10.0.0.0/8"
@@ -154,8 +152,6 @@ tests:
     values:
       - ../values.azure.yaml
     set:
-      # resourceGroup must equal the release name (kommodity.azure.validateNaming).
-      kommodity.provider.config.resourceGroup: test-cluster
       kommodity.network.ipv4.enabled: true
       kommodity.network.ipv4.public: true
       kommodity.network.ipv4.nodeCIDR: null

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -35,13 +35,13 @@ kommodity:
       #   allowedNamespaces: {}
     config:
       subscriptionID: <YOUR_SUBSCRIPTION_ID>
-      # Convention: name the resource group after the cluster (it must equal the
-      # Helm release name). The chart fails fast at install time if they differ —
-      # this catches a values file copied from another cluster without updating
-      # this field, which would otherwise silently share that cluster's resource
-      # group and corrupt both. Set allowSharedResourceGroup: true below to place
-      # multiple clusters in one resource group on purpose.
-      resourceGroup: <YOUR_RESOURCE_GROUP>
+      # Optional: defaults to the Helm release name. The chart fails fast at
+      # install time if an explicitly-set resourceGroup does not match the
+      # release name — this catches a values file copied from another cluster
+      # without updating this field, which would otherwise silently share that
+      # cluster's resource group and corrupt both. Set allowSharedResourceGroup:
+      # true below to place multiple clusters in one resource group on purpose.
+      # resourceGroup: <YOUR_RESOURCE_GROUP>
       location: westeurope
       # Resource group that holds the Talos managed image referenced by
       # talos.imageName. Combined with subscriptionID above, the chart builds the


### PR DESCRIPTION
## What

When `kommodity.provider.config.resourceGroup` is omitted from values, the chart now defaults it to the Helm release name (`.Release.Name`) instead of failing with a "missing required resourceGroup" error.

## Why

The naming guard (`kommodity.azure.validateNaming`) already enforces that `resourceGroup == .Release.Name` — with `allowSharedResourceGroup: true` as the only escape hatch. Requiring the user to set it explicitly to the same value as the release name is redundant in the common case. This removes a boilerplate field operators had to set correctly just to pass validation.

## Changes

- **`cluster.yaml`**: `resourceGroup` defaults to `.Release.Name` via `default`; the VNet fallback uses the same `$rg` variable
- **`_helpers.tpl`**: Updated guard comment to reflect that the default exists and the guard now only catches explicit mismatches
- **`values.azure.yaml`**: `resourceGroup` commented out, comments updated to mark it optional
- **Tests**: Removed suite-level `set` overrides that were only needed because the example values used a placeholder; changed "should fail when missing" to "should default to release name"
- **`azure-requirements.md`**: Documented as optional
- **`Chart.yaml`**: Bumped to `0.21.2`

## Behavior

| Scenario | Before | After |
|---|---|---|
| `resourceGroup` omitted | **fail** | defaults to `.Release.Name` |
| `resourceGroup` == release name | works | works |
| `resourceGroup` != release name | **fail** (guard) | **fail** (guard) |
| `resourceGroup` != release name + `allowSharedResourceGroup: true` | works | works |

All 154 helm unit tests pass.
