### PR TITLE
fix(capz): make provisioning VMs in Azure from image gallery work

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.0
+version: 0.22.1
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
@@ -16,7 +16,9 @@ spec:
       vmSize: {{ .Values.kommodity.controlplane.sku }}
       image:
         {{- include "kommodity.azure.image" . | nindent 8 }}
-      sshPublicKey: {{ if .Values.azure }}{{ default "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUZLeGlkQ1FxTzZZU3JKUHpKNlNPa1loRk9yZVpSb0JCNlZPVlVGNEtHb1ogdGFsb3Mta2V5Cg==" .Values.azure.sshPublicKey }}{{ else }}c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUZLeGlkQ1FxTzZZU3JKUHpKNlNPa1loRk9yZVpSb0JCNlZPVlVGNEtHb1ogdGFsb3Mta2V5Cg=={{ end }}
+      {{- if not (and .Values.azure .Values.azure.disableSSHPublicKey) }}
+      sshPublicKey: {{ dig "sshPublicKey" "" (.Values.azure | default dict) | quote }}
+      {{- end }}
       disableExtensionOperations: {{ if and .Values.azure (hasKey .Values.azure "disableExtensionOperations") }}{{ .Values.azure.disableExtensionOperations }}{{ else }}true{{ end }}
       osDisk:
         diskSizeGB: {{ .Values.kommodity.controlplane.os.disk.size }}
@@ -39,7 +41,9 @@ spec:
       vmSize: {{ $np.sku }}
       image:
         {{- include "kommodity.azure.image" $ | nindent 8 }}
-      sshPublicKey: {{ if $.Values.azure }}{{ default "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUZLeGlkQ1FxTzZZU3JKUHpKNlNPa1loRk9yZVpSb0JCNlZPVlVGNEtHb1ogdGFsb3Mta2V5Cg==" $.Values.azure.sshPublicKey }}{{ else }}c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUZLeGlkQ1FxTzZZU3JKUHpKNlNPa1loRk9yZVpSb0JCNlZPVlVGNEtHb1ogdGFsb3Mta2V5Cg=={{ end }}
+      {{- if not (and $.Values.azure $.Values.azure.disableSSHPublicKey) }}
+      sshPublicKey: {{ dig "sshPublicKey" "" ($.Values.azure | default dict) | quote }}
+      {{- end }}
       disableExtensionOperations: {{ if and $.Values.azure (hasKey $.Values.azure "disableExtensionOperations") }}{{ $.Values.azure.disableExtensionOperations }}{{ else }}true{{ end }}
       osDisk:
         diskSizeGB: {{ $np.os.disk.size }}

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -407,6 +407,45 @@ tests:
           value: false
         documentIndex: 1
 
+  - it: should render an empty sshPublicKey by default
+    template: templates/provider/azure/machinetemplate.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.sshPublicKey
+          value: ""
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.sshPublicKey
+          value: ""
+        documentIndex: 1
+
+  - it: should omit sshPublicKey when disableSSHPublicKey is set
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      azure.disableSSHPublicKey: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.sshPublicKey
+        documentIndex: 0
+      - notExists:
+          path: spec.template.spec.sshPublicKey
+        documentIndex: 1
+
+  - it: should still render sshPublicKey when disableSSHPublicKey is false
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      azure.disableSSHPublicKey: false
+      azure.sshPublicKey: my-key
+    asserts:
+      - equal:
+          path: spec.template.spec.sshPublicKey
+          value: my-key
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.sshPublicKey
+          value: my-key
+        documentIndex: 1
+
   - it: should not render AzureMachineTemplates for non-Azure providers
     template: templates/provider/azure/machinetemplate.yaml
     set:

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -258,3 +258,17 @@ talos:
   #     offer: talos
   #     sku: talos
   #     version: 1.13.0
+
+# Azure-specific overrides applied to the generated AzureMachineTemplates.
+# azure:
+#   # SSH public key (base64-encoded) injected into the VM osProfile. Defaults to
+#   # empty — Talos does not use Azure's provisioning agent, so no key is needed.
+#   sshPublicKey: <BASE64_ENCODED_PUBLIC_KEY>
+#   # Omit sshPublicKey entirely. REQUIRED when booting from a Shared Image Gallery
+#   # image definition with osState: Specialized (correct for Talos VHDs, which are
+#   # not generalized): any sshPublicKey makes CAPZ send an osProfile, which Azure
+#   # rejects for specialized images with
+#   # "Parameter OSProfile is not allowed with a specialized image."
+#   disableSSHPublicKey: true
+#   # Set spec.disableExtensionOperations on the AzureMachineTemplate (defaults to true).
+#   disableExtensionOperations: true


### PR DESCRIPTION
This unblocks booting VMs from Kommodity-flavoured Talos Linux images stored in an Azure Shared Image Gallery.

## Problem

`templates/provider/azure/machinetemplate.yaml` unconditionally set `sshPublicKey` (with a hardcoded base64 key) on the `AzureMachineTemplate`. CAPZ translates any `sshPublicKey` into an `osProfile` on the VM create call. Gallery image definitions for Talos must use `osState: Specialized` (Talos VHDs are not generalized), and Azure rejects `osProfile` for specialized images:

```
RESPONSE 400: InvalidParameter — "Parameter OSProfile is not allowed with a specialized image."
```

Talos manages SSH via machine config, not Azure's provisioning agent, so the key was never needed.

## Changes (`charts/kommodity-cluster`)

- **`sshPublicKey` now defaults to empty** — removed the hardcoded base64 key; renders `sshPublicKey: ""` unless overridden via `azure.sshPublicKey`.
- **New `azure.disableSSHPublicKey` flag** — omits the field entirely from `spec.template.spec` on both the controlplane and nodepool templates, so CAPZ emits no `osProfile`. Required for specialized gallery images.
- Documented the `azure` override block in `values.azure.yaml`.
- Bumped chart version `0.22.0` → `0.22.1`.
- Added unit tests covering the empty default, the omit-on-flag path, and the explicit-key path.

All 166 helm unit tests pass.
