### PR TITLE
fix(azure): render dataDisks into controlplane AzureMachineTemplate and machineSpecsHash

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.2
+version: 0.23.3
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -199,9 +199,6 @@ Any values that should trigger a new Machine template when changed should be add
 {{- with (dig "additionalVolumes" "" .poolValues) -}}
 	{{- $_ := set $data "additionalVolumes" . -}}
 {{- end -}}
-{{- with (dig "dataDisks" "" .poolValues) -}}
-	{{- $_ := set $data "dataDisks" . -}}
-{{- end -}}
 {{- $_ := set $data "publicNetworkEnabled" .allValues.kommodity.network.ipv4.public -}}
 {{- $zones := include "kommodity-cluster.poolZones" .poolValues | fromJsonArray -}}
 {{- if gt (len $zones) 0 -}}

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -199,6 +199,9 @@ Any values that should trigger a new Machine template when changed should be add
 {{- with (dig "additionalVolumes" "" .poolValues) -}}
 	{{- $_ := set $data "additionalVolumes" . -}}
 {{- end -}}
+{{- with (dig "dataDisks" "" .poolValues) -}}
+	{{- $_ := set $data "dataDisks" . -}}
+{{- end -}}
 {{- $_ := set $data "publicNetworkEnabled" .allValues.kommodity.network.ipv4.public -}}
 {{- $zones := include "kommodity-cluster.poolZones" .poolValues | fromJsonArray -}}
 {{- if gt (len $zones) 0 -}}

--- a/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
@@ -25,11 +25,11 @@ spec:
         osType: Linux
         managedDisk:
           storageAccountType: {{ default "Premium_LRS" .Values.kommodity.controlplane.os.disk.type }}
-      {{- if .Values.kommodity.controlplane.dataDisks }}
+      {{- if .Values.kommodity.controlplane.additionalVolumes }}
       dataDisks:
-        {{- range .Values.kommodity.controlplane.dataDisks }}
+        {{- range .Values.kommodity.controlplane.additionalVolumes }}
         - nameSuffix: {{ .nameSuffix }}
-          diskSizeGB: {{ .diskSizeGB }}
+          diskSizeGB: {{ .size }}
           lun: {{ .lun }}
           managedDisk:
             storageAccountType: {{ default "Premium_LRS" .storageAccountType }}
@@ -63,11 +63,11 @@ spec:
         osType: Linux
         managedDisk:
           storageAccountType: {{ default "Premium_LRS" $np.os.disk.type }}
-      {{- if $np.dataDisks }}
+      {{- if $np.additionalVolumes }}
       dataDisks:
-        {{- range $np.dataDisks }}
+        {{- range $np.additionalVolumes }}
         - nameSuffix: {{ .nameSuffix }}
-          diskSizeGB: {{ .diskSizeGB }}
+          diskSizeGB: {{ .size }}
           lun: {{ .lun }}
           managedDisk:
             storageAccountType: {{ default "Premium_LRS" .storageAccountType }}

--- a/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
@@ -32,7 +32,7 @@ spec:
           diskSizeGB: {{ .size }}
           lun: {{ .lun }}
           managedDisk:
-            storageAccountType: {{ default "Premium_LRS" .storageAccountType }}
+            storageAccountType: {{ default "Premium_LRS" .storageClassName }}
           {{- if .cachingType }}
           cachingType: {{ .cachingType }}
           {{- end }}
@@ -70,7 +70,7 @@ spec:
           diskSizeGB: {{ .size }}
           lun: {{ .lun }}
           managedDisk:
-            storageAccountType: {{ default "Premium_LRS" .storageAccountType }}
+            storageAccountType: {{ default "Premium_LRS" .storageClassName }}
           {{- if .cachingType }}
           cachingType: {{ .cachingType }}
           {{- end }}

--- a/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
@@ -25,6 +25,19 @@ spec:
         osType: Linux
         managedDisk:
           storageAccountType: {{ default "Premium_LRS" .Values.kommodity.controlplane.os.disk.type }}
+      {{- if .Values.kommodity.controlplane.dataDisks }}
+      dataDisks:
+        {{- range .Values.kommodity.controlplane.dataDisks }}
+        - nameSuffix: {{ .nameSuffix }}
+          diskSizeGB: {{ .diskSizeGB }}
+          lun: {{ .lun }}
+          managedDisk:
+            storageAccountType: {{ default "Premium_LRS" .storageAccountType }}
+          {{- if .cachingType }}
+          cachingType: {{ .cachingType }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
 
 {{- range $name, $np := .Values.kommodity.nodepools }}
 ---

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -215,12 +215,12 @@ tests:
           value: Standard_LRS
         documentIndex: 1
 
-  - it: should create dataDisks for worker when configured
+  - it: should create dataDisks for worker when additionalVolumes configured
     template: templates/provider/azure/machinetemplate.yaml
     set:
-      kommodity.nodepools.default.dataDisks:
+      kommodity.nodepools.default.additionalVolumes:
         - nameSuffix: data
-          diskSizeGB: 100
+          size: 100
           lun: 0
           storageAccountType: Premium_LRS
           cachingType: ReadWrite
@@ -249,12 +249,12 @@ tests:
           value: ReadWrite
         documentIndex: 1
 
-  - it: should create dataDisks for controlplane when configured
+  - it: should create dataDisks for controlplane when additionalVolumes configured
     template: templates/provider/azure/machinetemplate.yaml
     set:
-      kommodity.controlplane.dataDisks:
+      kommodity.controlplane.additionalVolumes:
         - nameSuffix: data
-          diskSizeGB: 64
+          size: 64
           lun: 0
           storageAccountType: Premium_LRS
           cachingType: ReadWrite
@@ -281,6 +281,19 @@ tests:
         documentIndex: 0
       - notExists:
           path: spec.template.spec.dataDisks
+        documentIndex: 1
+
+  - it: should mint a new AzureMachineTemplate when additionalVolumes change
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+          lun: 0
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-cluster-worker-default-[a-f0-9]{6}$
         documentIndex: 1
 
   - it: should create multiple AzureMachineTemplates for multiple nodepools

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -249,6 +249,40 @@ tests:
           value: ReadWrite
         documentIndex: 1
 
+  - it: should create dataDisks for controlplane when configured
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      kommodity.controlplane.dataDisks:
+        - nameSuffix: data
+          diskSizeGB: 64
+          lun: 0
+          storageAccountType: Premium_LRS
+          cachingType: ReadWrite
+    asserts:
+      - equal:
+          path: spec.template.spec.dataDisks[0].nameSuffix
+          value: data
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.dataDisks[0].diskSizeGB
+          value: 64
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.dataDisks[0].lun
+          value: 0
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.dataDisks[0].managedDisk.storageAccountType
+          value: Premium_LRS
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.dataDisks[0].cachingType
+          value: ReadWrite
+        documentIndex: 0
+      - notExists:
+          path: spec.template.spec.dataDisks
+        documentIndex: 1
+
   - it: should create multiple AzureMachineTemplates for multiple nodepools
     template: templates/provider/azure/machinetemplate.yaml
     set:

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -222,7 +222,7 @@ tests:
         - nameSuffix: data
           size: 100
           lun: 0
-          storageAccountType: Premium_LRS
+          storageClassName: Premium_LRS
           cachingType: ReadWrite
     asserts:
       - notExists:
@@ -256,7 +256,7 @@ tests:
         - nameSuffix: data
           size: 64
           lun: 0
-          storageAccountType: Premium_LRS
+          storageClassName: Premium_LRS
           cachingType: ReadWrite
     asserts:
       - equal:
@@ -294,6 +294,19 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: ^test-cluster-worker-default-[a-f0-9]{6}$
+        documentIndex: 1
+
+  - it: should default managedDisk.storageAccountType to Premium_LRS when storageClassName omitted
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+          lun: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.dataDisks[0].managedDisk.storageAccountType
+          value: Premium_LRS
         documentIndex: 1
 
   - it: should create multiple AzureMachineTemplates for multiple nodepools

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -216,10 +216,14 @@ kommodity:
           size: 30
           # Azure disk types: Standard_LRS, Premium_LRS, StandardSSD_LRS, UltraSSD_LRS
           type: Premium_LRS
-      # dataDisks:
-      #   # Optional: Additional data disks for the node
+      # additionalVolumes:
+      #   # Optional: additional data disks attached to the node. Uses the same
+      #   # `additionalVolumes` key as the Scaleway and KubeVirt providers; the
+      #   # Azure template maps `size` (GB) to the CAPZ `diskSizeGB` field.
+      #   # Azure-specific extras: nameSuffix (required by CAPZ), lun,
+      #   # storageAccountType (defaults to Premium_LRS), cachingType (optional).
       #   - nameSuffix: data
-      #     diskSizeGB: 100
+      #     size: 100
       #     lun: 0
       #     storageAccountType: Premium_LRS
       #     cachingType: ReadWrite

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -217,15 +217,14 @@ kommodity:
           # Azure disk types: Standard_LRS, Premium_LRS, StandardSSD_LRS, UltraSSD_LRS
           type: Premium_LRS
       # additionalVolumes:
-      #   # Optional: additional data disks attached to the node. Uses the same
-      #   # `additionalVolumes` key as the Scaleway and KubeVirt providers; the
+      #   # Optional: additional data disks attached to the node. The
       #   # Azure template maps `size` (GB) to the CAPZ `diskSizeGB` field.
       #   # Azure-specific extras: nameSuffix (required by CAPZ), lun,
-      #   # storageAccountType (defaults to Premium_LRS), cachingType (optional).
+      #   # storageClassName (defaults to Premium_LRS), cachingType (optional).
       #   - nameSuffix: data
       #     size: 100
       #     lun: 0
-      #     storageAccountType: Premium_LRS
+      #     storageClassName: Premium_LRS
       #     cachingType: ReadWrite
       labels:
         my-label: my-value


### PR DESCRIPTION
## Problem

Azure nodes could not attach data disks: the worker `AzureMachineTemplate` rendered a provider-specific `dataDisks` values key (added in #386), but the controlplane template had no such block, and `dataDisks` was not in `machineSpecsHash` — so adding disks to values neither attached a disk to control-plane VMs nor minted a new template. With a `strategicPatches.machine.disks` mount in the `TalosConfigTemplate`, new VMs booted Talos told to mount `/dev/sdb` with no disk attached, bricking node join and freezing any roll. Discovered on dev-ams99 after deploying local-path-provisioner.

## Fix

Align Azure with the cross-provider `additionalVolumes` interface already used by the Scaleway and KubeVirt providers (both share `size` in GB as the common field), instead of inventing a parallel `dataDisks` key:

1. **`templates/provider/azure/machinetemplate.yaml`** — read `additionalVolumes` (not `dataDisks`) for both controlplane and worker, rendering CAPZ `dataDisks` with `size` → `diskSizeGB`. Adds controlplane support (previously missing). Azure-specific extras (`nameSuffix`, `lun`, `storageAccountType`, `cachingType`) live alongside the common `size` field.
2. **`templates/_helpers.tpl`** — no change needed: `machineSpecsHash` already includes `additionalVolumes`, so attach-only changes roll a new `AzureMachineTemplate` via the existing hash. (The `dataDisks` hash entry added in the first commit is reverted.)
3. **`values.azure.yaml`** — example updated to `additionalVolumes` with `size`.

## Breaking change

Azure clusters using the `dataDisks` values key must rename it to `additionalVolumes` and `diskSizeGB` → `size`. Only dev-ams99 uses it (the sole Azure cluster; the rest are Scaleway) and it is updated in the deployments repo alongside the chart tag bump.

## Testing

- Updated helm-unittest cases to use `additionalVolumes` + `size` for both controlplane and worker, plus a hash-mint assertion.
- All 187 tests pass (`helm unittest charts/kommodity-cluster`).

Closes PLA-6241.
