### PR TITLE
feat(kommodity-cluster): emit UserVolumeConfig for additionalVolumes

### DIFF
--- a/charts/kommodity-cluster/templates/talos/configtemplate.yaml
+++ b/charts/kommodity-cluster/templates/talos/configtemplate.yaml
@@ -34,10 +34,10 @@ spec:
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
       {{- end }}
       {{- if $np.additionalVolumes }}
-      {{- /* UserVolumeConfig for data disks (Talos v1.13+) */ -}}
+      {{- /* Volume configs for data disks (Talos v1.13+) */ -}}
 {{- $kmsEndpoint := "" -}}
 {{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
-{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $np.additionalVolumes "kmsEndpoint" $kmsEndpoint) | nindent 6 }}
+{{- include "kommodity.talos.additionalVolumes" (dict "additionalVolumes" $np.additionalVolumes "kmsEndpoint" $kmsEndpoint) | nindent 6 }}
       {{- end }}
       {{- if $.Values.kommodity.security.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-attestation extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/configtemplate.yaml
+++ b/charts/kommodity-cluster/templates/talos/configtemplate.yaml
@@ -23,7 +23,7 @@ spec:
         "logLevel" $.Values.kommodity.logLevel
         "ccmEnabled" (dig "provider" "cloudControllerManager" "enabled" false $.Values.kommodity)
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled (gt (len (dig "additionalVolumes" list $np)) 0) }}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled (gt (len (default list $np.additionalVolumes)) 0) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- if not (empty $mergedPatch) }}
@@ -33,9 +33,11 @@ spec:
       {{- /* VolumeConfig for KMS disk encryption*/}}
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
       {{- end }}
-      {{- if gt (len (dig "additionalVolumes" list $np)) 0 }}
+      {{- if $np.additionalVolumes }}
       {{- /* UserVolumeConfig for data disks (Talos v1.13+) */ -}}
-{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $np.additionalVolumes) | nindent 6 }}
+{{- $kmsEndpoint := "" -}}
+{{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
+{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $np.additionalVolumes "kmsEndpoint" $kmsEndpoint) | nindent 6 }}
       {{- end }}
       {{- if $.Values.kommodity.security.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-attestation extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/configtemplate.yaml
+++ b/charts/kommodity-cluster/templates/talos/configtemplate.yaml
@@ -23,7 +23,7 @@ spec:
         "logLevel" $.Values.kommodity.logLevel
         "ccmEnabled" (dig "provider" "cloudControllerManager" "enabled" false $.Values.kommodity)
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled }}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled (gt (len (dig "additionalVolumes" list $np)) 0) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- if not (empty $mergedPatch) }}
@@ -32,6 +32,10 @@ spec:
       {{- if $.Values.kommodity.kms.enabled }}
       {{- /* VolumeConfig for KMS disk encryption*/}}
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
+      {{- end }}
+      {{- if gt (len (dig "additionalVolumes" list $np)) 0 }}
+      {{- /* UserVolumeConfig for data disks (Talos v1.13+) */ -}}
+{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $np.additionalVolumes) | nindent 6 }}
       {{- end }}
       {{- if $.Values.kommodity.security.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-attestation extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/controlplane.yaml
+++ b/charts/kommodity-cluster/templates/talos/controlplane.yaml
@@ -75,10 +75,10 @@ spec:
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
       {{- end }}
       {{- if $.Values.kommodity.controlplane.additionalVolumes }}
-      {{- /* UserVolumeConfig for data disks (Talos v1.13+) */ -}}
+      {{- /* Volume configs for data disks (Talos v1.13+) */ -}}
 {{- $kmsEndpoint := "" -}}
 {{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
-{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $.Values.kommodity.controlplane.additionalVolumes "kmsEndpoint" $kmsEndpoint) | nindent 6 }}
+{{- include "kommodity.talos.additionalVolumes" (dict "additionalVolumes" $.Values.kommodity.controlplane.additionalVolumes "kmsEndpoint" $kmsEndpoint) | nindent 6 }}
       {{- end }}
       {{- if or (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-autobootstrap extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/controlplane.yaml
+++ b/charts/kommodity-cluster/templates/talos/controlplane.yaml
@@ -63,7 +63,7 @@ spec:
         "disableProxy" $.Values.talos.disableKubeProxy
         "ccmEnabled" (dig "provider" "cloudControllerManager" "enabled" false $.Values.kommodity)
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled }}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled (gt (len (dig "additionalVolumes" list $.Values.kommodity.controlplane)) 0) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- /* Merged MachineConfig patch (labels, taints, annotations, env, installer, OIDC, CNI, proxy, CCM, user patches) */ -}}
@@ -73,6 +73,10 @@ spec:
       {{- if $.Values.kommodity.kms.enabled }}
       {{- /* VolumeConfig for disk encryption (Talos v1.12+) */ -}}
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
+      {{- end }}
+      {{- if gt (len (dig "additionalVolumes" list $.Values.kommodity.controlplane)) 0 }}
+      {{- /* UserVolumeConfig for data disks (Talos v1.13+) */ -}}
+{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $.Values.kommodity.controlplane.additionalVolumes) | nindent 6 }}
       {{- end }}
       {{- if or (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-autobootstrap extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/controlplane.yaml
+++ b/charts/kommodity-cluster/templates/talos/controlplane.yaml
@@ -63,7 +63,7 @@ spec:
         "disableProxy" $.Values.talos.disableKubeProxy
         "ccmEnabled" (dig "provider" "cloudControllerManager" "enabled" false $.Values.kommodity)
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled (gt (len (dig "additionalVolumes" list $.Values.kommodity.controlplane)) 0) }}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled (gt (len (default list $.Values.kommodity.controlplane.additionalVolumes)) 0) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- /* Merged MachineConfig patch (labels, taints, annotations, env, installer, OIDC, CNI, proxy, CCM, user patches) */ -}}
@@ -74,9 +74,11 @@ spec:
       {{- /* VolumeConfig for disk encryption (Talos v1.12+) */ -}}
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
       {{- end }}
-      {{- if gt (len (dig "additionalVolumes" list $.Values.kommodity.controlplane)) 0 }}
+      {{- if $.Values.kommodity.controlplane.additionalVolumes }}
       {{- /* UserVolumeConfig for data disks (Talos v1.13+) */ -}}
-{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $.Values.kommodity.controlplane.additionalVolumes) | nindent 6 }}
+{{- $kmsEndpoint := "" -}}
+{{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
+{{- include "kommodity.talos.userVolumes" (dict "additionalVolumes" $.Values.kommodity.controlplane.additionalVolumes "kmsEndpoint" $kmsEndpoint) | nindent 6 }}
       {{- end }}
       {{- if or (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-autobootstrap extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/user-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/user-volumes.yaml
@@ -1,38 +1,56 @@
 {{/*
-UserVolumeConfig documents for additional data volumes.
+Talos volume config documents for additional data volumes.
 Emitted from the same `additionalVolumes` list that drives the provider's
 dataDisks, so a single values entry provisions the cloud disk AND the Talos
-mount — no manual machine.disks strategic patch needed.
+volume — no manual machine.disks strategic patch needed.
 
-UserVolumeConfig (Talos v1.13+) auto-mounts at /var/mnt/<name> with a
-partition labelled u-<name>. This replaces the deprecated machine.disks field.
+Each additionalVolumes entry supports an optional `volumeType` field:
+  - "user" (default): UserVolumeConfig — formatted (xfs), mounted at /var/mnt/<name>.
+    Use for local-path-provisioner and other mounted-filesystem workloads.
+  - "raw": RawVolumeConfig — unformatted, unmounted raw block device.
+    Use for CSI provisioners (e.g. Ceph/Rook OSDs) that write directly to the
+    block device. The partition is labelled r-<name>.
 
-nameSuffix is required on every additionalVolume entry. It is already used
-by the Azure provider (CAPZ requires it); other providers should adopt it
-too — it doubles as the UserVolumeConfig name and the mount path suffix.
+nameSuffix is required on every entry — it doubles as the Talos volume name
+and (for user volumes) the mount path suffix.
 
-When KMS is enabled, each user volume is encrypted with luks2+KMS, matching
-the encryption applied to STATE and EPHEMERAL by volume-encryption.yaml.
+When KMS is enabled, each volume is encrypted with luks2+KMS, matching the
+encryption applied to STATE and EPHEMERAL by volume-encryption.yaml.
 
-See: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+See:
+  - UserVolumeConfig: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+  - RawVolumeConfig:  https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/rawvolumeconfig
 
-Usage: {{ include "kommodity.talos.userVolumes" (dict "additionalVolumes" .additionalVolumes "kmsEndpoint" .kmsEndpoint) }}
+Usage: {{ include "kommodity.talos.additionalVolumes" (dict "additionalVolumes" .additionalVolumes "kmsEndpoint" .kmsEndpoint) }}
 Returns empty string when additionalVolumes is not set or empty.
 */}}
-{{- define "kommodity.talos.userVolumes" -}}
+{{- define "kommodity.talos.additionalVolumes" -}}
 {{- $volumes := .additionalVolumes -}}
 {{- $kmsEndpoint := .kmsEndpoint -}}
 {{- if $volumes -}}
 {{- range $vol := $volumes }}
+{{- $name := required "additionalVolumes[].nameSuffix is required (used as Talos volume name and /var/mnt/<name> mount path)" $vol.nameSuffix -}}
+{{- $vtype := default "user" $vol.volumeType -}}
 - |
   apiVersion: v1alpha1
+  {{- if eq $vtype "raw" }}
+  kind: RawVolumeConfig
+  {{- else }}
   kind: UserVolumeConfig
-  name: {{ required "additionalVolumes[].nameSuffix is required (used as Talos volume name and /var/mnt/<name> mount path)" $vol.nameSuffix }}
+  {{- end }}
+  name: {{ $name }}
+  {{- if eq $vtype "raw" }}
+  provisioning:
+    diskSelector:
+      match: 'system_disk == false && disk.size > {{ printf "%vGiB" (sub $vol.size 1) }}'
+    maxSize: {{ printf "%vGiB" $vol.size }}
+  {{- else }}
   volumeType: disk
   provisioning:
     diskSelector:
       match: 'system_disk == false && disk.size > {{ printf "%vGiB" (sub $vol.size 1) }}'
     maxSize: {{ printf "%vGiB" $vol.size }}
+  {{- end }}
   {{- if $kmsEndpoint }}
   encryption:
     provider: luks2
@@ -41,6 +59,6 @@ Returns empty string when additionalVolumes is not set or empty.
         kms:
           endpoint: {{ $kmsEndpoint | quote }}
   {{- end }}
-{{- end }}
+{{ end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kommodity-cluster/templates/talos/user-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/user-volumes.yaml
@@ -1,40 +1,46 @@
 {{/*
 UserVolumeConfig documents for additional data volumes.
 Emitted from the same `additionalVolumes` list that drives the provider's
-dataDisks (Azure) or extra disks (other providers), so a single values entry
-provisions the cloud disk AND the Talos mount — no manual machine.disks
-strategic patch needed.
+dataDisks, so a single values entry provisions the cloud disk AND the Talos
+mount — no manual machine.disks strategic patch needed.
 
 UserVolumeConfig (Talos v1.13+) auto-mounts at /var/mnt/<name> with a
 partition labelled u-<name>. This replaces the deprecated machine.disks field.
 
-The diskSelector uses `!system_disk` to select the first non-OS disk. With
-a single data disk per node (the common case), this is unambiguous. If
-multiple data disks are needed in the future, add a diskSize-based selector
-or LUN-specific matching.
+nameSuffix is required on every additionalVolume entry. It is already used
+by the Azure provider (CAPZ requires it); other providers should adopt it
+too — it doubles as the UserVolumeConfig name and the mount path suffix.
+
+When KMS is enabled, each user volume is encrypted with luks2+KMS, matching
+the encryption applied to STATE and EPHEMERAL by volume-encryption.yaml.
 
 See: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
 
-Usage: {{ include "kommodity.talos.userVolumes" (dict "additionalVolumes" .poolValues.additionalVolumes) }}
+Usage: {{ include "kommodity.talos.userVolumes" (dict "additionalVolumes" .additionalVolumes "kmsEndpoint" .kmsEndpoint) }}
 Returns empty string when additionalVolumes is not set or empty.
 */}}
 {{- define "kommodity.talos.userVolumes" -}}
 {{- $volumes := .additionalVolumes -}}
+{{- $kmsEndpoint := .kmsEndpoint -}}
 {{- if $volumes -}}
-{{- range $vol := $volumes -}}
+{{- range $vol := $volumes }}
 - |
   apiVersion: v1alpha1
   kind: UserVolumeConfig
-  name: {{ $vol.nameSuffix }}
+  name: {{ required "additionalVolumes[].nameSuffix is required (used as Talos volume name and /var/mnt/<name> mount path)" $vol.nameSuffix }}
   volumeType: disk
   provisioning:
     diskSelector:
-      match: '!system_disk'
-    {{- if $vol.size }}
+      match: 'system_disk == false && disk.size > {{ printf "%vGiB" (sub $vol.size 1) }}'
     maxSize: {{ printf "%vGiB" $vol.size }}
-    {{- end }}
-  filesystem:
-    type: xfs
-{{- end -}}
+  {{- if $kmsEndpoint }}
+  encryption:
+    provider: luks2
+    keys:
+      - slot: 0
+        kms:
+          endpoint: {{ $kmsEndpoint | quote }}
+  {{- end }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/kommodity-cluster/templates/talos/user-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/user-volumes.yaml
@@ -1,0 +1,40 @@
+{{/*
+UserVolumeConfig documents for additional data volumes.
+Emitted from the same `additionalVolumes` list that drives the provider's
+dataDisks (Azure) or extra disks (other providers), so a single values entry
+provisions the cloud disk AND the Talos mount — no manual machine.disks
+strategic patch needed.
+
+UserVolumeConfig (Talos v1.13+) auto-mounts at /var/mnt/<name> with a
+partition labelled u-<name>. This replaces the deprecated machine.disks field.
+
+The diskSelector uses `!system_disk` to select the first non-OS disk. With
+a single data disk per node (the common case), this is unambiguous. If
+multiple data disks are needed in the future, add a diskSize-based selector
+or LUN-specific matching.
+
+See: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+
+Usage: {{ include "kommodity.talos.userVolumes" (dict "additionalVolumes" .poolValues.additionalVolumes) }}
+Returns empty string when additionalVolumes is not set or empty.
+*/}}
+{{- define "kommodity.talos.userVolumes" -}}
+{{- $volumes := .additionalVolumes -}}
+{{- if $volumes -}}
+{{- range $vol := $volumes -}}
+- |
+  apiVersion: v1alpha1
+  kind: UserVolumeConfig
+  name: {{ $vol.nameSuffix }}
+  volumeType: disk
+  provisioning:
+    diskSelector:
+      match: '!system_disk'
+    {{- if $vol.size }}
+    maxSize: {{ printf "%vGiB" $vol.size }}
+    {{- end }}
+  filesystem:
+    type: xfs
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kommodity-cluster/tests/kubevirt_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/kubevirt_provider_test.yaml
@@ -180,8 +180,10 @@ tests:
     set:
       kommodity.provider.config.storageClassName: ceph-block
       kommodity.nodepools.default.additionalVolumes:
-        - size: 50
-        - size: 100
+        - nameSuffix: data
+          size: 50
+        - nameSuffix: logs
+          size: 100
           storageClassName: fast-ssd
     asserts:
       - equal:

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -308,3 +308,101 @@ tests:
       - equal:
           path: spec.version
           value: "controlplane-kubernetes-version"
+
+  # UserVolumeConfig tests
+  - it: should emit UserVolumeConfig for controlplane additionalVolumes
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.controlplane.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+    asserts:
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "name: data"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "volumeType: disk"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "maxSize: 64GiB"
+
+  - it: should emit UserVolumeConfig for worker additionalVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+
+  - it: should emit multiple UserVolumeConfig documents for multiple volumes
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.controlplane.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+        - nameSuffix: logs
+          size: 32
+          lun: 1
+    asserts:
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "name: data"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[2]
+          pattern: "name: logs"
+
+  - it: should not emit UserVolumeConfig when additionalVolumes is unset
+    template: templates/talos/controlplane.yaml
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[0]
+          pattern: "UserVolumeConfig"
+      - not: true
+        matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "UserVolumeConfig"
+      - not: true
+        matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[2]
+          pattern: "UserVolumeConfig"
+
+  - it: should emit KMS encryption on UserVolumeConfig when kms is enabled
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.kms.enabled: true
+      kommodity.controlplane.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+    asserts:
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[3]
+          pattern: "provider: luks2"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[3]
+          pattern: "endpoint: \"https://kms.example.com\""
+
+  - it: should not emit encryption when kms is disabled
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.kms.enabled: false
+      kommodity.controlplane.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "luks2"

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -406,3 +406,57 @@ tests:
         matchRegex:
           path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
           pattern: "luks2"
+
+  - it: should emit RawVolumeConfig when volumeType is raw
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: ceph-osd
+          size: 128
+          lun: 0
+          volumeType: raw
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "kind: RawVolumeConfig"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "name: ceph-osd"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "volumeType"
+
+  - it: should emit UserVolumeConfig by default when volumeType is omitted
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "volumeType: disk"
+
+  - it: should emit both UserVolumeConfig and RawVolumeConfig for mixed volumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 64
+          lun: 0
+        - nameSuffix: ceph-osd
+          size: 128
+          lun: 1
+          volumeType: raw
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[2]
+          pattern: "kind: RawVolumeConfig"

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -221,13 +221,18 @@ kommodity:
       #   # Azure template maps `size` (GB) to the CAPZ `diskSizeGB` field.
       #   # Azure-specific extras: nameSuffix (required by CAPZ), lun,
       #   # storageClassName (defaults to Premium_LRS), cachingType (optional).
-      #   # nameSuffix is also used as the Talos UserVolumeConfig name — the
-      #   # disk is auto-mounted at /var/mnt/<nameSuffix> with partition label u-<nameSuffix>.
+      #   # nameSuffix is also used as the Talos volume name. For user volumes
+      #   # (default) the disk is auto-mounted at /var/mnt/<nameSuffix>.
+      #   #
+      #   # volumeType: "user" (default) or "raw"
+      #   #   user = UserVolumeConfig — formatted (xfs), mounted at /var/mnt/<name>
+      #   #   raw  = RawVolumeConfig — unformatted, unmounted, for CSI/Ceph OSDs
       #   - nameSuffix: data
       #     size: 100
       #     lun: 0
       #     storageClassName: Premium_LRS
       #     cachingType: ReadWrite
+      #     # volumeType: raw  # uncomment for Ceph/Rook raw block devices
       labels:
         my-label: my-value
       annotations:

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -221,6 +221,8 @@ kommodity:
       #   # Azure template maps `size` (GB) to the CAPZ `diskSizeGB` field.
       #   # Azure-specific extras: nameSuffix (required by CAPZ), lun,
       #   # storageClassName (defaults to Premium_LRS), cachingType (optional).
+      #   # nameSuffix is also used as the Talos UserVolumeConfig name — the
+      #   # disk is auto-mounted at /var/mnt/<nameSuffix> with partition label u-<nameSuffix>.
       #   - nameSuffix: data
       #     size: 100
       #     lun: 0

--- a/charts/kommodity-cluster/values.kubevirt.yaml
+++ b/charts/kommodity-cluster/values.kubevirt.yaml
@@ -114,7 +114,8 @@ kommodity:
         disk:
           size: 20
       additionalVolumes:
-        - size: 10 # size in GB
+        - nameSuffix: data # required: used as Talos volume name and /var/mnt/<name> mount path
+          size: 10 # size in GB
       #     storageClassName: fast-ssd # optional, defaults to provider.config.storageClassName if set
 
       # Optional: specify GPU resources

--- a/charts/kommodity-cluster/values.scaleway.yaml
+++ b/charts/kommodity-cluster/values.scaleway.yaml
@@ -83,7 +83,9 @@ kommodity:
         disk:
           size: 20
       # additionalVolumes:
-      #   - size: 50 # size in GB
+      #   # nameSuffix is required — used as Talos volume name and /var/mnt/<nameSuffix> mount path.
+      #   - nameSuffix: data
+      #     size: 50 # size in GB
       #     type: block # optional, defaults to block (local, block, scratch)
       #     iops: 5000 # optional, only valid for block volumes (5000 or 15000)
       labels:


### PR DESCRIPTION
## Problem

`additionalVolumes` provisions Azure data disks via AzureMachineTemplate but the Talos side (partitioning + mounting) requires a separate manual `machine.disks` strategic patch. In Talos v1.13, `machine.disks` is deprecated in favour of `UserVolumeConfig`, and the mountpoint must be under `/var/` (the read-only root blocks `/mnt/`). This has already caused a boot failure on dev-ams99 where `mkdir /mnt/data` failed with "read-only file system".

## Fix

Emit `UserVolumeConfig` documents automatically from the same `additionalVolumes` list that drives `dataDisks`. A single values entry now provisions the cloud disk AND the Talos mount — no manual `machine.disks` strategic patch needed.

`UserVolumeConfig` (Talos v1.13+) auto-mounts at `/var/mnt/<nameSuffix>` with partition label `u-<nameSuffix>`.

### Files changed

- `templates/talos/user-volumes.yaml` (new) — `kommodity.talos.userVolumes` helper, emits one `UserVolumeConfig` per additionalVolume entry
- `templates/talos/controlplane.yaml` — include userVolumes in CP strategicPatches, gated by `additionalVolumes` presence
- `templates/talos/configtemplate.yaml` — same for worker TalosConfigTemplate
- `Chart.yaml` — version bump 0.23.3 → 0.24.0
- `values.azure.yaml`, `values.kubevirt.yaml`, `values.scaleway.yaml` — document `nameSuffix` and `/var/mnt/<name>` mount path
- `tests/kubevirt_provider_test.yaml` — add `nameSuffix` to existing additionalVolumes test values
- `tests/talos_provider_test.yaml` — add 6 new tests

### Key design decisions

- **`nameSuffix` required**: fails at render time if missing (not just Azure — all providers). `nameSuffix` is the Talos volume name and the mount path suffix.
- **diskSelector**: `system_disk == false && disk.size > (N-1)GiB` — avoids ambiguity with Azure temp/resource disks that `!system_disk` alone would match.
- **KMS encryption**: when `kommodity.kms.enabled`, each user volume gets luks2+KMS encryption matching STATE/EPHEMERAL.
- **Nil-safe**: `additionalVolumes: null` or unset renders cleanly (uses `if` idiom, not `dig`+`len`).

### Hash rotation

`additionalVolumes` is already in `talosConfigHash` (`_helpers.tpl:179`), so adding/changing volumes already rotates the TalosConfigTemplate name. No hash change needed.

### Verification

All 194 helm-unittest tests pass (188 existing + 6 new). Render verified with multi-volume, KMS on/off, null, and missing-nameSuffix cases.

### Migration note

Clusters already carrying a manual `machine.disks` strategic patch (e.g. dev-ams99) should remove it from their deployments-repo values before or together with upgrading to this chart version. Otherwise both the manual patch and the new `UserVolumeConfig` will target the same disk.
