### PR TITLE
feat(libkapi): unify server extension points into WithServerFactory

### DIFF
--- a/pkg/libkapi/README.md
+++ b/pkg/libkapi/README.md
@@ -83,54 +83,56 @@ kubectl --server=http://127.0.0.1:8080 get namespaces
 kubectl --server=http://127.0.0.1:8080 apply -f my-deployment.yaml
 ```
 
-### Mounting custom HTTP handlers
+### Extending the built server
 
-`WithHTTPHandlerFactory` lets you mount your own routes alongside the built
-API server, on the same address and port. Pass it more than once to mount
-several factories; they run in the order given:
+`WithServerFactory` lets you extend the built server alongside the API
+server, on the same address and port. Each registered factory is called
+with a `*libkapi.Ctx` exposing whatever it needs:
+
+- `c.HTTPMux()` — mount routes on the server's shared `*http.ServeMux`.
+- `c.GRPCServer()` — register services on the server's `*grpc.Server`,
+  building it (and registering reflection) the first time it's called.
+  Requests are then routed by Content-Type: anything starting with
+  `application/grpc` goes to the gRPC server, everything else goes to the
+  HTTP mux.
+- `c.LoopbackConfig()` — the server's own privileged
+  (system:masters-equivalent) identity, for building a client (typed,
+  dynamic, or controller-runtime) that a registered service can use once
+  the server is actually serving requests.
+
+Pass `WithServerFactory` more than once to register several factories
+against the same `Ctx`; they run in the order given.
 
 ```go
 server, err := libkapi.New(ctx,
 	libkapi.WithStorage("sqlite://local.db"),
-	libkapi.WithHTTPHandlerFactory(func(mux *http.ServeMux) error {
-		mux.HandleFunc("GET /healthz/custom", func(w http.ResponseWriter, r *http.Request) {
+	libkapi.WithServerFactory(func(c *libkapi.Ctx) error {
+		c.HTTPMux().HandleFunc("GET /healthz/custom", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		return nil
-	}),
-)
-```
+		kubeClient, err := kubernetes.NewForConfig(c.LoopbackConfig())
+		if err != nil {
+			return err
+		}
 
-Every unmatched request still falls through to the Kubernetes API server's
-own handler.
-
-### Mounting a gRPC server
-
-`WithGRPCServerFactory` lets you register gRPC services alongside the built
-API server, multiplexed onto the same address and port as everything else.
-Requests are routed by Content-Type: anything starting with
-`application/grpc` goes to the gRPC server, everything else goes to the HTTP
-mux (built API server plus any `WithHTTPHandlerFactory` routes). Pass it
-more than once to register several factories against the same
-`*grpc.Server`; they run in the order given. Reflection is registered
-automatically.
-
-```go
-server, err := libkapi.New(ctx,
-	libkapi.WithStorage("sqlite://local.db"),
-	libkapi.WithGRPCServerFactory(func(grpcServer *grpc.Server) error {
-		myservicepb.RegisterMyServiceServer(grpcServer, &myServiceImpl{})
+		myservicepb.RegisterMyServiceServer(c.GRPCServer(), &myServiceImpl{kubeClient: kubeClient})
 
 		return nil
 	}),
 )
 ```
 
-Registering at least one factory switches the listener to serve h2c (HTTP/2
-over plaintext), since gRPC requires HTTP/2 and `WithTLS` is not yet
-implemented. Servers that never call `WithGRPCServerFactory` are unaffected
-and stay on plain HTTP/1.1.
+Every unmatched HTTP request still falls through to the Kubernetes API
+server's own handler. If some factory calls `c.GRPCServer()`, the listener
+switches to serve h2c (HTTP/2 over plaintext), since gRPC requires HTTP/2
+and `WithTLS` is not yet implemented; a server where no factory ever calls
+`c.GRPCServer()` is unaffected and stays on plain HTTP/1.1.
+
+`WithHTTPHandlerFactory` and `WithGRPCServerFactory` still work, as thin,
+deprecated wrappers around `WithServerFactory` — prefer `WithServerFactory`
+for new code, since it also gives a factory access to whichever of `Ctx`'s
+other resources it needs.
 
 ### Graceful shutdown
 
@@ -241,8 +243,9 @@ auth-specific alike — pass any combination, in any order.
 | `WithAddr(addr string)`                          | Sets the listener address, e.g. `":8080"`. Defaults to `":"+$PORT`, falling back to `":8080"` if `PORT` is unset or invalid.                                                                           |
 | `WithStorage(storage string)`                    | Sets the storage connection string. See [Storage](#storage).                                                                                                                                           |
 | `WithLogger(logger *slog.Logger)`                | Sets the logger for libkapi's own output and the bridged klog/gRPC/logrus output. See [Logging](#logging). Defaults to `slog.Default()`.                                                               |
-| `WithHTTPHandlerFactory(f HTTPHandlerFactory)`   | Mounts an extra set of routes. See [Mounting custom HTTP handlers](#mounting-custom-http-handlers). Repeatable.                                                                                        |
-| `WithGRPCServerFactory(f GRPCServerFactory)`     | Registers gRPC services, multiplexed onto the same address and port. See [Mounting a gRPC server](#mounting-a-grpc-server). Repeatable.                                                                |
+| `WithServerFactory(f ServerFactory)`             | Extends the built server via `Ctx` (HTTP mux, gRPC server, loopback client config). See [Extending the built server](#extending-the-built-server). Repeatable.                                        |
+| `WithHTTPHandlerFactory(f HTTPHandlerFactory)`   | Deprecated: use `WithServerFactory` instead. Mounts an extra set of routes. See [Extending the built server](#extending-the-built-server). Repeatable.                                                |
+| `WithGRPCServerFactory(f GRPCServerFactory)`     | Deprecated: use `WithServerFactory` instead. Registers gRPC services, multiplexed onto the same address and port. See [Extending the built server](#extending-the-built-server). Repeatable.          |
 | `WithScheme(scheme *runtime.Scheme)`             | Registers additional types beyond the standard API groups libkapi wires by default.                                                                                                                    |
 | `WithTLS(cfg TLSConfig)`                         | Reserved for future use; passing it makes `New` return `ErrNotImplemented`.                                                                                                                            |
 | `WithOIDC(cfg OIDCConfig)`                       | Adds an OIDC bearer-token authenticator. Fetches the issuer's discovery document at `IssuerURL/.well-known/openid-configuration` during `New`.                                                         |
@@ -475,13 +478,36 @@ added.
 | `CertFile` | `string` |
 | `KeyFile`  | `string` |
 
+### `type Ctx struct`
+
+Exposes the resources available to a `ServerFactory`. New accessors can be
+added here over time without changing `ServerFactory`'s signature.
+
+| Method                                     | Description                                                                                                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HTTPMux() *http.ServeMux`                  | The server's shared mux, for mounting additional routes.                                                                                         |
+| `LoopbackConfig() *restclient.Config`       | The server's own privileged (system:masters-equivalent) identity, for building whatever client a factory needs.                                  |
+| `GRPCServer() *grpc.Server`                 | The server's gRPC server, built (with reflection registered) the first time it's called. See [Extending the built server](#extending-the-built-server). |
+
+### `type ServerFactory func(*Ctx) error`
+
+libkapi's extension-point type. Each factory passed via `WithServerFactory`
+is called with a shared `*Ctx` during `New`; use whichever of its resources
+you need. Replaces the narrower `HTTPHandlerFactory` and `GRPCServerFactory`.
+
 ### `type HTTPHandlerFactory func(*http.ServeMux) error`
 
-libkapi's extension-point type. Each factory passed via
-`WithHTTPHandlerFactory` is called with the server's shared `*http.ServeMux`
-during `New`; register whatever routes you need on it. Any request that
-doesn't match a registered route falls through to the built API server's own
-handler.
+Deprecated: use `ServerFactory` via `WithServerFactory` instead. Each factory
+passed via `WithHTTPHandlerFactory` is called with the server's shared
+`*http.ServeMux` during `New`; register whatever routes you need on it. Any
+request that doesn't match a registered route falls through to the built API
+server's own handler.
+
+### `type GRPCServerFactory func(*grpc.Server) error`
+
+Deprecated: use `ServerFactory` via `WithServerFactory` instead. Each factory
+passed via `WithGRPCServerFactory` is called with the server's shared
+`*grpc.Server` during `New`; register whatever gRPC services you need on it.
 
 ### `type Server struct`
 

--- a/pkg/libkapi/config.go
+++ b/pkg/libkapi/config.go
@@ -34,8 +34,7 @@ type config struct {
 	storage          string
 	logger           *slog.Logger
 	tls              *TLSConfig
-	handlers         []HTTPHandlerFactory
-	grpcFactories    []GRPCServerFactory
+	serverFactories  []ServerFactory
 	scheme           *runtime.Scheme
 	authOpts         []auth.Option
 	controllers      []Controller

--- a/pkg/libkapi/ctx.go
+++ b/pkg/libkapi/ctx.go
@@ -1,0 +1,55 @@
+package libkapi
+
+import (
+	"net/http"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+	restclient "k8s.io/client-go/rest"
+)
+
+// Ctx exposes the resources available to a ServerFactory: the server's
+// shared HTTP mux, its privileged loopback identity, and - via GRPCServer -
+// a lazily built gRPC server. New accessors can be added here over time
+// without changing ServerFactory's signature, so extending what a factory
+// can reach is never a breaking change.
+type Ctx struct {
+	mux            *http.ServeMux
+	loopbackConfig *restclient.Config
+	grpcServer     *grpc.Server
+}
+
+// HTTPMux returns the server's shared HTTP mux, for mounting additional
+// routes alongside the built API server. Any request that doesn't match a
+// registered route falls through to the API server's own handler.
+func (c *Ctx) HTTPMux() *http.ServeMux {
+	return c.mux
+}
+
+// LoopbackConfig returns a shallow copy of the built server's own
+// privileged (system:masters-equivalent) identity - the same one
+// Controller/Manager and libkapi's post-start/pre-shutdown hooks use - so a
+// factory can build whatever client it needs (typed, dynamic, or
+// controller-runtime) without requiring a full Controller/Manager for
+// simple work. A copy, rather than the shared config itself, is returned so
+// a factory customizing QPS/Burst/UserAgent/RateLimiter for its own client
+// can't silently change those settings for every other consumer of the
+// server's loopback identity - the same reasoning as configForGC's own copy.
+func (c *Ctx) LoopbackConfig() *restclient.Config {
+	return restclient.CopyConfig(c.loopbackConfig)
+}
+
+// GRPCServer returns the server's gRPC server, building it (and
+// registering reflection) the first time it's called. A built server only
+// pays for the h2c/HTTP2 listener switch (see server.go's newHTTPServer) if
+// some ServerFactory actually calls GRPCServer - one that only touches
+// HTTPMux leaves the listener on plain HTTP/1.1. Factories run
+// sequentially, so no locking is needed here.
+func (c *Ctx) GRPCServer() *grpc.Server {
+	if c.grpcServer == nil {
+		c.grpcServer = grpc.NewServer()
+		reflection.Register(c.grpcServer)
+	}
+
+	return c.grpcServer
+}

--- a/pkg/libkapi/grpc.go
+++ b/pkg/libkapi/grpc.go
@@ -1,13 +1,10 @@
 package libkapi
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 )
 
 // grpcContentTypePrefix identifies gRPC requests so muxHandler can route
@@ -19,6 +16,9 @@ const grpcContentTypePrefix = "application/grpc"
 // server. It is libkapi's own equivalent of
 // combinedserver.GRPCServerFactory, kept dependency-free so libkapi never
 // imports pkg/combinedserver.
+//
+// Deprecated: use ServerFactory via WithServerFactory instead, which also
+// exposes the HTTP mux and the server's loopback client config through Ctx.
 type GRPCServerFactory func(*grpc.Server) error
 
 // WithGRPCServerFactory adds a gRPC server alongside the built API server,
@@ -33,60 +33,21 @@ type GRPCServerFactory func(*grpc.Server) error
 // (HTTP/2 over plaintext) so gRPC's own HTTP/2 requirement is met without
 // WithTLS (not yet implemented). Servers that never call this option are
 // unaffected: the listener stays on plain HTTP/1.1. The h2c switch itself is
-// applied in server.go via http.Server.Protocols, not here, because
-// unencrypted HTTP/2 is a listener-level concern (the *http.Server), not a
-// handler-level one.
+// applied in server.go's newHTTPServer via http.Server.Protocols, not here,
+// because unencrypted HTTP/2 is a listener-level concern (the *http.Server),
+// not a handler-level one.
+//
+// Deprecated: use WithServerFactory instead.
 func WithGRPCServerFactory(factory GRPCServerFactory) Option {
-	return func(_ context.Context, cfg *config) error {
-		cfg.grpcFactories = append(cfg.grpcFactories, factory)
-
-		return nil
-	}
-}
-
-// buildHandler builds the gRPC server (if any factories were registered)
-// and returns it alongside a handler that routes gRPC requests to the
-// gRPC server and everything else to mux. The handler is returned
-// unwrapped; unencrypted HTTP/2 (h2c) support is configured on the
-// *http.Server in server.go when grpcServer is non-nil, via the Protocols
-// field (replaces the deprecated golang.org/x/net/http2/h2c handler
-// wrapper). Returns a nil gRPC server (and mux, unwrapped) when no
-// WithGRPCServerFactory calls were made.
-func buildHandler(factories []GRPCServerFactory, mux *http.ServeMux) (*grpc.Server, http.Handler, error) {
-	grpcServer, err := buildGRPCServer(factories)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return grpcServer, muxHandler(grpcServer, mux), nil
-}
-
-// buildGRPCServer builds a *grpc.Server, registers reflection, then runs
-// every factory against it in order. Returns a nil server (and nil error)
-// when factories is empty, so callers only pay for gRPC - and the h2c
-// listener switch applied in server.go - when WithGRPCServerFactory was
-// actually used.
-func buildGRPCServer(factories []GRPCServerFactory) (*grpc.Server, error) {
-	if len(factories) == 0 {
-		return nil, nil //nolint:nilnil // absence of a gRPC server is a valid, common outcome, not an error.
-	}
-
-	grpcServer := grpc.NewServer()
-	reflection.Register(grpcServer)
-
-	for i, factory := range factories {
-		err := factory(grpcServer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to run gRPC server factory %d: %w", i, err)
-		}
-	}
-
-	return grpcServer, nil
+	return WithServerFactory(func(c *Ctx) error {
+		return factory(c.GRPCServer())
+	})
 }
 
 // muxHandler routes a request to grpcServer when its Content-Type
 // identifies it as gRPC, otherwise to httpHandler. If grpcServer is nil (no
-// WithGRPCServerFactory calls), every request goes to httpHandler.
+// ServerFactory ever called Ctx.GRPCServer), every request goes to
+// httpHandler.
 func muxHandler(grpcServer *grpc.Server, httpHandler http.Handler) http.Handler {
 	if grpcServer == nil {
 		return httpHandler

--- a/pkg/libkapi/handler.go
+++ b/pkg/libkapi/handler.go
@@ -1,28 +1,21 @@
 package libkapi
 
-import (
-	"fmt"
-	"net/http"
-)
+import "net/http"
 
 // HTTPHandlerFactory mounts additional routes onto the server's shared mux.
-// It is libkapi's own equivalent of combinedserver.HTTPMuxFactory, kept
-// dependency-free so libkapi never imports pkg/combinedserver.
+//
+// Deprecated: use ServerFactory via WithServerFactory instead, which also
+// exposes the gRPC server and the server's loopback client config through Ctx.
 type HTTPHandlerFactory func(*http.ServeMux) error
 
-// buildMux runs every factory against a fresh mux, then falls back every
-// unmatched request to apiHandler - the built API server's own handler.
-func buildMux(factories []HTTPHandlerFactory, apiHandler http.Handler) (*http.ServeMux, error) {
-	mux := http.NewServeMux()
-
-	for i, factory := range factories {
-		err := factory(mux)
-		if err != nil {
-			return nil, fmt.Errorf("failed to run HTTP handler factory %d: %w", i, err)
-		}
-	}
-
-	mux.Handle("/", apiHandler)
-
-	return mux, nil
+// WithHTTPHandlerFactory mounts an additional set of routes onto the
+// server's shared mux, alongside the built API server. Can be passed more
+// than once; factories run in the order given.
+//
+// Deprecated: use WithServerFactory instead, which also exposes the gRPC
+// server and the server's loopback client config through Ctx.
+func WithHTTPHandlerFactory(factory HTTPHandlerFactory) Option {
+	return WithServerFactory(func(c *Ctx) error {
+		return factory(c.HTTPMux())
+	})
 }

--- a/pkg/libkapi/options.go
+++ b/pkg/libkapi/options.go
@@ -62,17 +62,6 @@ func WithTLS(tls TLSConfig) Option {
 	}
 }
 
-// WithHTTPHandlerFactory mounts an additional set of routes onto the
-// server's shared mux, alongside the built API server. Can be passed more
-// than once; factories run in the order given.
-func WithHTTPHandlerFactory(factory HTTPHandlerFactory) Option {
-	return func(_ context.Context, cfg *config) error {
-		cfg.handlers = append(cfg.handlers, factory)
-
-		return nil
-	}
-}
-
 // WithScheme lets the caller register additional types beyond the standard
 // API groups libkapi wires by default.
 func WithScheme(scheme *runtime.Scheme) Option {

--- a/pkg/libkapi/posthooks.go
+++ b/pkg/libkapi/posthooks.go
@@ -18,10 +18,13 @@ import (
 // newLoopbackClientConfig doc for the crash a failing post-start hook used
 // to cause before the loopback client had a privileged identity).
 //
-// loopbackConfig is the server's own privileged (system:masters-equivalent)
-// identity - the same one Controller/Manager use - so a hook can build
-// whatever client it needs without requiring a full Controller/Manager for
-// simple background work (e.g. a heartbeat loop).
+// loopbackConfig is a fresh copy of the server's own privileged
+// (system:masters-equivalent) identity - the same one Controller/Manager
+// use - so a hook can build whatever client it needs without requiring a
+// full Controller/Manager for simple background work (e.g. a heartbeat
+// loop). It is a copy, not the shared config itself, so a hook customizing
+// QPS/Burst/UserAgent/RateLimiter for its own client can't affect the
+// Manager, other hooks, or Ctx.LoopbackConfig - see that method's own doc.
 type PostStartHookFunc func(ctx context.Context, loopbackConfig *restclient.Config) error
 
 // WithPostStartHook registers fn to run once, after ListenAndServe's
@@ -41,7 +44,8 @@ func WithPostStartHook(fn PostStartHookFunc) Option {
 // server's listener closes - so it still has a real chance to make one last
 // privileged API call (e.g. deleting an object a PostStartHook created).
 // Bounded by Shutdown's own ctx, the same window the controller manager's
-// own stop gets.
+// own stop gets. loopbackConfig is a fresh copy, for the same reason given
+// on PostStartHookFunc.
 type PreShutdownHookFunc func(ctx context.Context, loopbackConfig *restclient.Config) error
 
 // WithPreShutdownHook registers fn to run once during Shutdown, before the

--- a/pkg/libkapi/server.go
+++ b/pkg/libkapi/server.go
@@ -485,9 +485,9 @@ func registerKeyHooks(
 
 // buildDelegationChain builds the CRD server -> standard-API delegate ->
 // aggregator delegation chain and returns the aggregator plus the
-// caller-facing gRPC server (nil unless WithGRPCServerFactory was used) and
-// handler (custom HTTP handlers and, if any, gRPC routing layered over the
-// aggregator's own Handler).
+// caller-facing gRPC server (nil unless some ServerFactory called
+// Ctx.GRPCServer) and handler (custom HTTP handlers and, if any, gRPC
+// routing layered over the aggregator's own Handler).
 func buildDelegationChain(
 	cfg config,
 	genericServerConfig *genericapiserver.RecommendedConfig,
@@ -523,14 +523,10 @@ func buildDelegationChain(
 	// and OpenAPI routes on the PathRecorderMux, and calling it twice (once
 	// here, once in ListenAndServe) produces "duplicate path registration"
 	// errors. The Handler is already populated by NewWithDelegate, so
-	// buildMux can mount it before PrepareRun runs. ListenAndServe calls
-	// PrepareRun exactly once before NonBlockingRunWithContext.
-	mux, err := buildMux(cfg.handlers, aggregatorServer.GenericAPIServer.Handler)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	grpcServer, handler, err := buildHandler(cfg.grpcFactories, mux)
+	// runServerFactories can mount it before PrepareRun runs. ListenAndServe
+	// calls PrepareRun exactly once before NonBlockingRunWithContext.
+	grpcServer, handler, err := runServerFactories(
+		cfg.serverFactories, genericServerConfig.LoopbackClientConfig, aggregatorServer.GenericAPIServer.Handler)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -735,10 +731,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// shutdownGRPCServer gracefully stops s.grpcServer (if WithGRPCServerFactory
-// was used), waiting for in-flight RPCs to finish. Bounded by ctx, the same
-// way Shutdown bounds its wait for the controller manager: if ctx is done
-// before GracefulStop returns, it falls back to Stop, which closes
+// shutdownGRPCServer gracefully stops s.grpcServer (if some ServerFactory
+// called Ctx.GRPCServer), waiting for in-flight RPCs to finish. Bounded by
+// ctx, the same way Shutdown bounds its wait for the controller manager: if
+// ctx is done before GracefulStop returns, it falls back to Stop, which closes
 // connections immediately rather than letting Shutdown hang forever on a
 // client holding a stream open. A no-op when grpcServer is nil.
 func (s *Server) shutdownGRPCServer(ctx context.Context) {

--- a/pkg/libkapi/server.go
+++ b/pkg/libkapi/server.go
@@ -67,8 +67,10 @@ type Server struct {
 	internalHooksCancel context.CancelFunc
 
 	// loopbackConfig is the server's own privileged (system:masters-equivalent)
-	// identity, handed to each PostStartHookFunc/PreShutdownHookFunc - the
-	// same config Controller/Manager use internally (see buildManager).
+	// identity - the same config Controller/Manager use internally (see
+	// buildManager). A copy (see runPostStartHooks/runPreShutdownHooks) is
+	// handed to each PostStartHookFunc/PreShutdownHookFunc, never this field
+	// itself, so a hook can't mutate it out from under other consumers.
 	loopbackConfig *restclient.Config
 
 	// postStartHooks and preShutdownHooks are the WithPostStartHook/
@@ -919,7 +921,7 @@ func (s *Server) startManager() {
 // ListenAndServe can fail startup without crashing the process.
 func (s *Server) runPostStartHooks(ctx context.Context) error {
 	for i, hook := range s.postStartHooks {
-		err := hook(ctx, s.loopbackConfig)
+		err := hook(ctx, restclient.CopyConfig(s.loopbackConfig))
 		if err != nil {
 			return fmt.Errorf("post-start hook %d failed: %w", i, err)
 		}
@@ -947,7 +949,7 @@ func (s *Server) runPreShutdownHooks(ctx context.Context) {
 		defer close(done)
 
 		for i, hook := range s.preShutdownHooks {
-			err := hook(ctx, s.loopbackConfig)
+			err := hook(ctx, restclient.CopyConfig(s.loopbackConfig))
 			if err != nil {
 				s.logger.Error("Pre-shutdown hook failed", "index", i, "error", err)
 			}

--- a/pkg/libkapi/serverfactory.go
+++ b/pkg/libkapi/serverfactory.go
@@ -1,0 +1,62 @@
+package libkapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc"
+	restclient "k8s.io/client-go/rest"
+)
+
+// ServerFactory extends the built server using whatever combination of
+// Ctx's resources it needs: register gRPC services via Ctx.GRPCServer,
+// mount HTTP routes via Ctx.HTTPMux, and/or build a privileged client from
+// Ctx.LoopbackConfig. It replaces the narrower GRPCServerFactory and
+// HTTPHandlerFactory, which remain as deprecated adapters implemented in
+// terms of WithServerFactory.
+type ServerFactory func(*Ctx) error
+
+// WithServerFactory registers factory to run once, while the server is
+// being built, against a shared Ctx exposing the HTTP mux, the gRPC server
+// (built lazily - see Ctx.GRPCServer), and the server's own loopback client
+// config. Can be passed more than once; factories run in registration
+// order against the same Ctx.
+func WithServerFactory(factory ServerFactory) Option {
+	return func(_ context.Context, cfg *config) error {
+		cfg.serverFactories = append(cfg.serverFactories, factory)
+
+		return nil
+	}
+}
+
+// runServerFactories runs every registered ServerFactory (including those
+// registered through the deprecated WithGRPCServerFactory/
+// WithHTTPHandlerFactory adapters) against one shared Ctx, then mounts
+// apiHandler as the mux's fallback route. Returns the gRPC server (nil
+// unless some factory called Ctx.GRPCServer) alongside the handler
+// buildServer should actually serve: muxHandler routes gRPC-Content-Type
+// requests to it when non-nil. The listener's own h2c switch is applied
+// separately, by server.go's newHTTPServer, based on whether the returned
+// gRPC server is nil.
+func runServerFactories(
+	factories []ServerFactory,
+	loopbackConfig *restclient.Config,
+	apiHandler http.Handler,
+) (*grpc.Server, http.Handler, error) {
+	factoryCtx := &Ctx{
+		mux:            http.NewServeMux(),
+		loopbackConfig: loopbackConfig,
+	}
+
+	for i, factory := range factories {
+		err := factory(factoryCtx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to run server factory %d: %w", i, err)
+		}
+	}
+
+	factoryCtx.mux.Handle("/", apiHandler)
+
+	return factoryCtx.grpcServer, muxHandler(factoryCtx.grpcServer, factoryCtx.mux), nil
+}

--- a/pkg/libkapi/serverfactory_test.go
+++ b/pkg/libkapi/serverfactory_test.go
@@ -1,0 +1,139 @@
+package libkapi_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kommodity-io/kommodity/pkg/libkapi"
+	"github.com/stretchr/testify/require"
+)
+
+// serverFactoryTestShutdownTimeout bounds the server shutdown run from t.Cleanup.
+const serverFactoryTestShutdownTimeout = 10 * time.Second
+
+// loopbackHealthServer implements grpc_health_v1.HealthServer, reporting
+// SERVING only if kubeClient (built from Ctx.LoopbackConfig by the
+// WithServerFactory registration in TestServerEndToEnd_WithServerFactory) can
+// reach the built API server - proving the loopback config handed to a
+// ServerFactory is a real, privileged, working client, not just a non-nil
+// struct, and that it still works once used from a request handler
+// (long after the ServerFactory itself returned) - the pattern the KMS
+// service needs.
+type loopbackHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+
+	kubeClient kubernetes.Interface
+}
+
+func (s *loopbackHealthServer) Check(
+	ctx context.Context, _ *grpc_health_v1.HealthCheckRequest,
+) (*grpc_health_v1.HealthCheckResponse, error) {
+	_, err := s.kubeClient.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
+	if err != nil {
+		//nolint:nilerr // a failed probe is reported as NOT_SERVING, not as an RPC error.
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+		}, nil
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+// TestServerEndToEnd_WithServerFactory verifies that a single
+// WithServerFactory registration can use all three of Ctx's resources
+// together: HTTPMux to mount a route, GRPCServer to register a gRPC
+// service (proving it multiplexes onto the same listener exactly like
+// WithGRPCServerFactory), and LoopbackConfig to build a client the gRPC
+// service uses at request time.
+func TestServerEndToEnd_WithServerFactory(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	addr := libkapi.FreeAddr(t)
+	dbPath := filepath.Join(t.TempDir(), "libkapi-serverfactory.db")
+
+	server, err := libkapi.New(ctx,
+		libkapi.WithAddr(addr),
+		libkapi.WithStorage("sqlite://"+dbPath),
+		libkapi.WithServerFactory(func(factoryCtx *libkapi.Ctx) error {
+			factoryCtx.HTTPMux().HandleFunc("GET /hello", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("hello"))
+			})
+
+			kubeClient, err := kubernetes.NewForConfig(factoryCtx.LoopbackConfig())
+			if err != nil {
+				return fmt.Errorf("failed to build loopback client: %w", err)
+			}
+
+			grpc_health_v1.RegisterHealthServer(
+				factoryCtx.GRPCServer(), &loopbackHealthServer{kubeClient: kubeClient})
+
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+
+	go func() {
+		_ = server.ListenAndServe(ctx)
+	}()
+
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), serverFactoryTestShutdownTimeout)
+		defer shutdownCancel()
+
+		_ = server.Shutdown(shutdownCtx)
+	})
+
+	libkapi.WaitForHealthz(t, "http://"+addr+"/healthz")
+
+	assertHelloRoute(t, "http://"+addr+"/hello")
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	callCtx, callCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer callCancel()
+
+	resp, err := client.Check(callCtx, &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+// TestNew_ServerFactoryError verifies that an error returned by a
+// ServerFactory fails New instead of silently building a partially
+// configured Server.
+func TestNew_ServerFactoryError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	addr := libkapi.FreeAddr(t)
+	dbPath := filepath.Join(t.TempDir(), "libkapi-serverfactory-error.db")
+
+	_, err := libkapi.New(ctx,
+		libkapi.WithAddr(addr),
+		libkapi.WithStorage("sqlite://"+dbPath),
+		libkapi.WithServerFactory(func(*libkapi.Ctx) error {
+			return errGRPCFactoryTest
+		}),
+	)
+	require.ErrorIs(t, err, errGRPCFactoryTest)
+}


### PR DESCRIPTION
## Summary

- Adds `libkapi.Ctx`, exposing `HTTPMux()`, `LoopbackConfig()`, and a lazily-built `GRPCServer()` to a single new `ServerFactory func(*Ctx) error` type, registered via `WithServerFactory`.
- `WithGRPCServerFactory`/`WithHTTPHandlerFactory` (and their `GRPCServerFactory`/`HTTPHandlerFactory` types) remain, now implemented as deprecated, backward-compatible one-line adapters onto `WithServerFactory` — no breaking change.
- Motivation: a service like the KMS needs to read/write Kubernetes resources stored in the control-plane server it's embedded in (e.g. disk-encryption key Secrets), which means its gRPC registration needs the server's own privileged loopback client config, not just a `*grpc.Server`. `Ctx` is designed to grow (more accessors over time) without ever changing `ServerFactory`'s signature again.
- `Ctx.GRPCServer()` builds the `*grpc.Server` (and registers reflection) lazily, on first call, so the existing "a server that never touches gRPC stays on plain HTTP/1.1, no h2c switch" behavior is preserved even though the new `ServerFactory` type can't statically declare whether it'll use gRPC.

## Test plan

- [x] `go test ./pkg/libkapi/...` — 111 tests pass, including new `TestServerEndToEnd_WithServerFactory` (exercises `HTTPMux`, `GRPCServer`, and `LoopbackConfig` together — a gRPC health check that queries the API server via a client built from the loopback config) and `TestNew_ServerFactoryError`, plus the existing `WithGRPCServerFactory`/`WithHTTPHandlerFactory` tests (now exercising the deprecated adapters) unchanged.
- [x] `make lint` — 0 issues.
- [x] `make build` — builds `bin/kommodity` successfully.
- [x] `make test` — full repo suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)