### PR TITLE
fix(talosproxy): reject overlapping CIDR registrations

### DIFF
--- a/pkg/talosproxy/cidr_registry.go
+++ b/pkg/talosproxy/cidr_registry.go
@@ -27,16 +27,42 @@ func NewCIDRRegistry() *CIDRRegistry {
 	}
 }
 
-// Register adds or updates a CIDR mapping for a cluster.
-func (r *CIDRRegistry) Register(clusterName string, namespace string, cidr *net.IPNet) {
+// Register adds or updates a CIDR mapping for a cluster. It returns an error
+// if the CIDR overlaps a CIDR already registered for a different cluster;
+// re-registering the same cluster with a new CIDR is always allowed.
+func (r *CIDRRegistry) Register(
+	clusterName string,
+	namespace string,
+	cidr *net.IPNet,
+) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	for existingCluster, entry := range r.entries {
+		if existingCluster == clusterName {
+			continue
+		}
+
+		if cidrsOverlap(entry.CIDR, cidr) {
+			return fmt.Errorf("%w: cluster %q (%s) overlaps existing cluster %q (%s)",
+				ErrCIDROverlap, clusterName, cidr.String(), existingCluster, entry.CIDR.String())
+		}
+	}
 
 	r.entries[clusterName] = &CIDREntry{
 		ClusterName: clusterName,
 		Namespace:   namespace,
 		CIDR:        cidr,
 	}
+
+	return nil
+}
+
+// cidrsOverlap reports whether two CIDR blocks overlap. Two power-of-two aligned
+// CIDR blocks overlap if and only if one contains the network address of the
+// other, so checking containment in both directions is a complete overlap test.
+func cidrsOverlap(a, b *net.IPNet) bool {
+	return a.Contains(b.IP) || b.Contains(a.IP)
 }
 
 // Deregister removes a cluster's CIDR mapping.

--- a/pkg/talosproxy/cidr_registry.go
+++ b/pkg/talosproxy/cidr_registry.go
@@ -28,8 +28,10 @@ func NewCIDRRegistry() *CIDRRegistry {
 }
 
 // Register adds or updates a CIDR mapping for a cluster. It returns an error
-// if the CIDR overlaps a CIDR already registered for a different cluster;
-// re-registering the same cluster with a new CIDR is always allowed.
+// if the CIDR overlaps a CIDR already registered for a different cluster, or
+// if the cluster name is already registered under a different namespace.
+// Re-registering the same cluster (same name and namespace) with a new CIDR
+// is always allowed.
 func (r *CIDRRegistry) Register(
 	clusterName string,
 	namespace string,
@@ -40,7 +42,17 @@ func (r *CIDRRegistry) Register(
 
 	for existingCluster, entry := range r.entries {
 		if existingCluster == clusterName {
-			continue
+			// Same name and namespace: re-registration, skip overlap check.
+			if entry.Namespace == namespace {
+				continue
+			}
+
+			// Same cluster name in a different namespace would collide with
+			// the existing entry and bypass overlap detection. The tunnel
+			// pool and kubeconfig fetch key by cluster name only, so cluster
+			// names must be globally unique; reject instead of overwriting.
+			return fmt.Errorf("%w: cluster %q already registered in namespace %q",
+				ErrClusterNameConflict, clusterName, entry.Namespace)
 		}
 
 		if cidrsOverlap(entry.CIDR, cidr) {

--- a/pkg/talosproxy/cidr_registry_test.go
+++ b/pkg/talosproxy/cidr_registry_test.go
@@ -24,7 +24,7 @@ func TestCIDRRegistry_RegisterAndLookup(t *testing.T) {
 	registry := talosproxy.NewCIDRRegistry()
 	cidr := mustParseCIDR(t, "10.200.0.0/20")
 
-	registry.Register("cluster-a", "default", cidr)
+	require.NoError(t, registry.Register("cluster-a", "default", cidr))
 
 	entry, err := registry.Lookup(net.ParseIP("10.200.0.5"))
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestCIDRRegistry_LookupNotFound(t *testing.T) {
 	registry := talosproxy.NewCIDRRegistry()
 	cidr := mustParseCIDR(t, "10.200.0.0/20")
 
-	registry.Register("cluster-a", "default", cidr)
+	require.NoError(t, registry.Register("cluster-a", "default", cidr))
 
 	_, err := registry.Lookup(net.ParseIP("192.168.1.1"))
 	require.Error(t, err)
@@ -52,8 +52,8 @@ func TestCIDRRegistry_MultipleClusters(t *testing.T) {
 	cidrA := mustParseCIDR(t, "10.200.0.0/20")
 	cidrB := mustParseCIDR(t, "10.201.0.0/20")
 
-	registry.Register("cluster-a", "ns-a", cidrA)
-	registry.Register("cluster-b", "ns-b", cidrB)
+	require.NoError(t, registry.Register("cluster-a", "ns-a", cidrA))
+	require.NoError(t, registry.Register("cluster-b", "ns-b", cidrB))
 
 	entryA, err := registry.Lookup(net.ParseIP("10.200.0.5"))
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestCIDRRegistry_Deregister(t *testing.T) {
 	registry := talosproxy.NewCIDRRegistry()
 	cidr := mustParseCIDR(t, "10.200.0.0/20")
 
-	registry.Register("cluster-a", "default", cidr)
+	require.NoError(t, registry.Register("cluster-a", "default", cidr))
 	registry.Deregister("cluster-a")
 
 	_, err := registry.Lookup(net.ParseIP("10.200.0.5"))
@@ -85,10 +85,10 @@ func TestCIDRRegistry_Len(t *testing.T) {
 	assert.Equal(t, 0, registry.Len())
 
 	cidr := mustParseCIDR(t, "10.200.0.0/20")
-	registry.Register("cluster-a", "default", cidr)
+	require.NoError(t, registry.Register("cluster-a", "default", cidr))
 	assert.Equal(t, 1, registry.Len())
 
-	registry.Register("cluster-b", "default", mustParseCIDR(t, "10.201.0.0/20"))
+	require.NoError(t, registry.Register("cluster-b", "default", mustParseCIDR(t, "10.201.0.0/20")))
 	assert.Equal(t, 2, registry.Len())
 
 	registry.Deregister("cluster-a")
@@ -102,8 +102,8 @@ func TestCIDRRegistry_OverwriteExisting(t *testing.T) {
 	cidrOld := mustParseCIDR(t, "10.200.0.0/20")
 	cidrNew := mustParseCIDR(t, "10.202.0.0/20")
 
-	registry.Register("cluster-a", "default", cidrOld)
-	registry.Register("cluster-a", "default", cidrNew)
+	require.NoError(t, registry.Register("cluster-a", "default", cidrOld))
+	require.NoError(t, registry.Register("cluster-a", "default", cidrNew))
 
 	// Old CIDR should no longer match
 	_, err := registry.Lookup(net.ParseIP("10.200.0.5"))
@@ -115,4 +115,48 @@ func TestCIDRRegistry_OverwriteExisting(t *testing.T) {
 	assert.Equal(t, "cluster-a", entry.ClusterName)
 
 	assert.Equal(t, 1, registry.Len())
+}
+
+func TestCIDRRegistry_RejectsOverlappingCIDR(t *testing.T) {
+	t.Parallel()
+
+	registry := talosproxy.NewCIDRRegistry()
+	supernet := mustParseCIDR(t, "10.0.0.0/8")
+	subnet := mustParseCIDR(t, "10.200.16.0/20")
+
+	require.NoError(t, registry.Register("cluster-a", "default", supernet))
+
+	err := registry.Register("cluster-b", "default", subnet)
+	require.Error(t, err)
+	require.ErrorIs(t, err, talosproxy.ErrCIDROverlap)
+
+	// Overlapping cluster must not be registered.
+	assert.Equal(t, 1, registry.Len())
+
+	_, lookupErr := registry.Lookup(net.ParseIP("10.200.16.5"))
+	require.NoError(t, lookupErr, "supernet should still own the address space")
+}
+
+func TestCIDRRegistry_RejectsOverlappingReRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry := talosproxy.NewCIDRRegistry()
+	cidrA := mustParseCIDR(t, "10.200.0.0/20")
+	cidrB := mustParseCIDR(t, "10.201.0.0/20")
+	overlapping := mustParseCIDR(t, "10.0.0.0/8")
+
+	require.NoError(t, registry.Register("cluster-a", "default", cidrA))
+	require.NoError(t, registry.Register("cluster-b", "default", cidrB))
+
+	// Re-registering cluster-a with a CIDR overlapping cluster-b must fail and
+	// leave cluster-a's original entry intact.
+	err := registry.Register("cluster-a", "default", overlapping)
+	require.Error(t, err)
+	require.ErrorIs(t, err, talosproxy.ErrCIDROverlap)
+
+	assert.Equal(t, 2, registry.Len())
+
+	entry, lookupErr := registry.Lookup(net.ParseIP("10.200.0.5"))
+	require.NoError(t, lookupErr)
+	assert.Equal(t, "cluster-a", entry.ClusterName)
 }

--- a/pkg/talosproxy/cidr_registry_test.go
+++ b/pkg/talosproxy/cidr_registry_test.go
@@ -160,3 +160,46 @@ func TestCIDRRegistry_RejectsOverlappingReRegistration(t *testing.T) {
 	require.NoError(t, lookupErr)
 	assert.Equal(t, "cluster-a", entry.ClusterName)
 }
+
+func TestCIDRRegistry_RejectsSameNameDifferentNamespace(t *testing.T) {
+	t.Parallel()
+
+	registry := talosproxy.NewCIDRRegistry()
+	cidrA := mustParseCIDR(t, "10.200.0.0/20")
+	cidrB := mustParseCIDR(t, "10.201.0.0/20")
+
+	require.NoError(t, registry.Register("cluster-a", "ns-a", cidrA))
+
+	// Same name, different namespace must be rejected instead of silently
+	// overwriting the existing entry or bypassing the overlap check.
+	err := registry.Register("cluster-a", "ns-b", cidrB)
+	require.Error(t, err)
+	require.ErrorIs(t, err, talosproxy.ErrClusterNameConflict)
+
+	// The original entry must remain intact.
+	assert.Equal(t, 1, registry.Len())
+
+	entry, lookupErr := registry.Lookup(net.ParseIP("10.200.0.5"))
+	require.NoError(t, lookupErr)
+	assert.Equal(t, "cluster-a", entry.ClusterName)
+	assert.Equal(t, "ns-a", entry.Namespace)
+}
+
+func TestCIDRRegistry_SameNameSameNamespaceAllowsReRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry := talosproxy.NewCIDRRegistry()
+	cidrOld := mustParseCIDR(t, "10.200.0.0/20")
+	cidrNew := mustParseCIDR(t, "10.201.0.0/20")
+
+	require.NoError(t, registry.Register("cluster-a", "ns-a", cidrOld))
+	require.NoError(t, registry.Register("cluster-a", "ns-a", cidrNew))
+
+	// New CIDR should match, old should not.
+	entry, err := registry.Lookup(net.ParseIP("10.201.0.5"))
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-a", entry.ClusterName)
+
+	_, err = registry.Lookup(net.ParseIP("10.200.0.5"))
+	require.Error(t, err)
+}

--- a/pkg/talosproxy/connect_handler_retry_test.go
+++ b/pkg/talosproxy/connect_handler_retry_test.go
@@ -126,7 +126,7 @@ func newRetryTestRegistry(t *testing.T) *talosproxy.CIDRRegistry {
 	registry := talosproxy.NewCIDRRegistry()
 	_, cidr, err := net.ParseCIDR("10.200.0.0/20")
 	require.NoError(t, err)
-	registry.Register("test-cluster", "default", cidr)
+	require.NoError(t, registry.Register("test-cluster", "default", cidr))
 
 	return registry
 }

--- a/pkg/talosproxy/connect_handler_test.go
+++ b/pkg/talosproxy/connect_handler_test.go
@@ -185,7 +185,7 @@ func TestConnectHandler_TunnelDialFailure(t *testing.T) {
 	_, cidr, err := net.ParseCIDR("10.200.0.0/20")
 	require.NoError(t, err)
 
-	registry.Register("test-cluster", "default", cidr)
+	require.NoError(t, registry.Register("test-cluster", "default", cidr))
 
 	listener := startTestProxyServer(t, handler)
 

--- a/pkg/talosproxy/errors.go
+++ b/pkg/talosproxy/errors.go
@@ -8,6 +8,9 @@ import "errors"
 var (
 	// ErrCIDRNotFound is returned when no registered CIDR matches the given IP address.
 	ErrCIDRNotFound = errors.New("no registered CIDR matches the given IP")
+	// ErrCIDROverlap is returned when a CIDR being registered overlaps a CIDR
+	// already registered for a different cluster.
+	ErrCIDROverlap = errors.New("CIDR overlaps an existing cluster CIDR")
 	// ErrTunnelNotReady is returned when the port-forward tunnel is not yet established.
 	ErrTunnelNotReady = errors.New("tunnel is not ready")
 	// ErrTunnelClosed is returned when the tunnel has been closed.

--- a/pkg/talosproxy/errors.go
+++ b/pkg/talosproxy/errors.go
@@ -11,6 +11,10 @@ var (
 	// ErrCIDROverlap is returned when a CIDR being registered overlaps a CIDR
 	// already registered for a different cluster.
 	ErrCIDROverlap = errors.New("CIDR overlaps an existing cluster CIDR")
+	// ErrClusterNameConflict is returned when a cluster name is already
+	// registered under a different namespace. Cluster names must be globally
+	// unique because the tunnel pool and kubeconfig fetch key by name only.
+	ErrClusterNameConflict = errors.New("cluster name already registered in a different namespace")
 	// ErrTunnelNotReady is returned when the port-forward tunnel is not yet established.
 	ErrTunnelNotReady = errors.New("tunnel is not ready")
 	// ErrTunnelClosed is returned when the tunnel has been closed.

--- a/pkg/talosproxy/proxy.go
+++ b/pkg/talosproxy/proxy.go
@@ -140,9 +140,15 @@ func (p *Proxy) Start(ctx context.Context) error {
 	return nil
 }
 
-// RegisterCluster registers a new cluster CIDR with the proxy.
-func (p *Proxy) RegisterCluster(clusterName string, namespace string, cidr *net.IPNet) {
-	p.cidrRegistry.Register(clusterName, namespace, cidr)
+// RegisterCluster registers a new cluster CIDR with the proxy. It returns an
+// error if the CIDR overlaps a CIDR already registered for a different cluster.
+func (p *Proxy) RegisterCluster(clusterName string, namespace string, cidr *net.IPNet) error {
+	err := p.cidrRegistry.Register(clusterName, namespace, cidr)
+	if err != nil {
+		return fmt.Errorf("failed to register cluster %s: %w", clusterName, err)
+	}
+
+	return nil
 }
 
 // DeregisterCluster removes a cluster from the proxy.

--- a/pkg/talosproxy/proxy_test.go
+++ b/pkg/talosproxy/proxy_test.go
@@ -30,7 +30,7 @@ func TestProxy_RegisterAndDeregisterCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	// Register should not panic
-	proxy.RegisterCluster("cluster-a", "default", cidr)
+	require.NoError(t, proxy.RegisterCluster("cluster-a", "default", cidr))
 
 	// Deregister should not panic
 	proxy.DeregisterCluster("cluster-a")

--- a/pkg/talosproxy/reconciler.go
+++ b/pkg/talosproxy/reconciler.go
@@ -126,7 +126,11 @@ func (r *Reconciler) handleClusterRegistration(
 		zap.String("namespace", cluster.Namespace),
 		zap.String("cidr", cidr.String()))
 
-	r.Proxy.RegisterCluster(cluster.Name, cluster.Namespace, cidr)
+	err = r.Proxy.RegisterCluster(cluster.Name, cluster.Namespace, cidr)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to register cluster %s with proxy: %w",
+			cluster.Name, err)
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/talosproxy/reconciler_test.go
+++ b/pkg/talosproxy/reconciler_test.go
@@ -113,7 +113,7 @@ func TestReconciler_AnnotationRemovalDeregisters(t *testing.T) {
 
 	_, cidr, err := net.ParseCIDR("10.20.0.0/16")
 	require.NoError(t, err)
-	proxy.RegisterCluster("annot-cluster", "team-c", cidr)
+	require.NoError(t, proxy.RegisterCluster("annot-cluster", "team-c", cidr))
 	require.Equal(t, 1, proxy.CIDRRegistryForTest().Len())
 
 	cluster := &clusterv1.Cluster{
@@ -142,7 +142,7 @@ func TestReconciler_ClusterDeletionDeregisters(t *testing.T) {
 
 	_, cidr, err := net.ParseCIDR("10.30.0.0/16")
 	require.NoError(t, err)
-	proxy.RegisterCluster("gone-cluster", "team-d", cidr)
+	require.NoError(t, proxy.RegisterCluster("gone-cluster", "team-d", cidr))
 	require.Equal(t, 1, proxy.CIDRRegistryForTest().Len())
 
 	// No Cluster resource exists in the fake client → reconciler hits the NotFound branch.
@@ -155,6 +155,38 @@ func TestReconciler_ClusterDeletionDeregisters(t *testing.T) {
 
 	assert.Equal(t, 0, proxy.CIDRRegistryForTest().Len(),
 		"a deleted cluster must be deregistered from the proxy")
+}
+
+func TestReconciler_OverlappingCIDRReturnsError(t *testing.T) {
+	t.Parallel()
+
+	scheme := newReconcilerScheme(t)
+	proxy := newReconcilerProxy(t)
+
+	// Pre-register a broad CIDR that subsumes the cluster's CIDR.
+	_, cidrExisting, err := net.ParseCIDR("10.0.0.0/8")
+	require.NoError(t, err)
+	require.NoError(t, proxy.RegisterCluster("other-cluster", "team-a", cidrExisting))
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "overlap-cluster",
+			Namespace:   "team-b",
+			Annotations: map[string]string{testCIDRAnnotation: "10.200.16.0/20"},
+		},
+	}
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+	reconciler := &talosproxy.Reconciler{Client: kubeClient, Proxy: proxy}
+
+	_, err = reconciler.Reconcile(context.Background(), reconcileRequest(cluster.Name, cluster.Namespace))
+	require.Error(t, err)
+	require.ErrorIs(t, err, talosproxy.ErrCIDROverlap)
+
+	// The overlapping cluster must not have been registered.
+	assert.Equal(t, 1, proxy.CIDRRegistryForTest().Len(),
+		"overlapping cluster must not be registered")
 }
 
 // Compile-time guard that the reconciler still satisfies the controller-runtime Reconciler interface.


### PR DESCRIPTION
The CIDR registry routes intercepted Talos gRPC connections to the
correct workload cluster tunnel via first-match Lookup. When two clusters
registered overlapping CIDRs (e.g. a broad 10.0.0.0/8 supernet and a
narrower 10.200.16.0/20 subnet), the randomized Go map iteration made
Lookup return either cluster non-deterministically. Connections for the
narrower cluster were sometimes routed through the wrong cluster's proxy
tunnel, which could not reach the target node, causing gRPC
DeadlineExceeded health-check failures that deadlocked control-plane
rollouts (machine stuck in WaitingForRemediation with no remediation
strategy, while the MHC saw the node as Ready).

Register now returns ErrCIDROverlap when a CIDR overlaps one already
registered for a different cluster, surfacing the conflict at
registration time so it can be fixed instead of silently misrouting.
Same-cluster re-registration remains allowed so a cluster can update its
own CIDR. With overlaps impossible, the existing first-match Lookup is
deterministic.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Paul Thuriot <pth@corti.ai>
