### PR TITLE
feat(server): embed default audit policy and enable audit logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,31 +406,33 @@ connection. Drop it on any host, point it at a database, and run.
 
 Kommodity is configured via environment variables.
 
-| Variable                                           | Description                                                       | Default                 |
-| -------------------------------------------------- | ----------------------------------------------------------------- | ----------------------- |
-| `KOMMODITY_PORT`                                   | Port for the Kommodity server                                     | `5000`                  |
-| `KOMMODITY_BASE_URL`                               | Base URL for the Kommodity server                                 | `http://localhost:5000` |
-| `KOMMODITY_DB_URI`                                 | PostgreSQL connection URI                                         | (none)                  |
-| `KOMMODITY_DEVELOPMENT_MODE`                       | Enable development mode                                           | `false`                 |
-| `KOMMODITY_INSECURE_DISABLE_AUTHENTICATION`        | Disable authentication for local development                      | `false`                 |
-| `KOMMODITY_ADMIN_GROUP`                            | Group name granted cluster-admin equivalence                      | (none)                  |
-| `KOMMODITY_OIDC_ISSUER_URL`                        | OIDC issuer URL                                                   | (none)                  |
-| `KOMMODITY_OIDC_CLIENT_ID`                         | OIDC client ID                                                    | (none)                  |
-| `KOMMODITY_OIDC_USERNAME_CLAIM`                    | OIDC claim used for the username                                  | `email`                 |
-| `KOMMODITY_OIDC_GROUPS_CLAIM`                      | OIDC claim used for groups                                        | `groups`                |
-| `KOMMODITY_INFRASTRUCTURE_PROVIDERS`               | Comma-separated providers to enable                               | all                     |
-| `KOMMODITY_ATTESTATION_NONCE_TTL`                  | TTL for attestation nonces (e.g. `5m`, `1h`)                      | `5m`                    |
-| `KOMMODITY_AUDIT_POLICY_FILE_PATH`                 | Path to a custom Kubernetes audit policy file                     | embedded default        |
-| `KOMMODITY_AUDIT_DISABLED`                         | Disable audit logging entirely                                    | `false`                 |
-| `KOMMODITY_TALOS_PROXY_ENABLED`                    | Enable the HTTP CONNECT Talos gRPC proxy                          | `true`                  |
-| `KOMMODITY_TALOS_PROXY_PORT`                       | Local listen port for the proxy                                   | `15050`                 |
-| `KOMMODITY_TALOS_PROXY_NAMESPACE`                  | Namespace of the talos-cluster-proxy service in workload clusters | `talos-cluster-proxy`   |
-| `KOMMODITY_TALOS_PROXY_SERVICE_NAME`               | Name of the talos-cluster-proxy service                           | `talos-cluster-proxy`   |
-| `KOMMODITY_TALOS_PROXY_IDLE_TIMEOUT`               | Idle timeout before unused tunnels are closed                     | `1m`                    |
-| `KOMMODITY_GARBAGE_COLLECTOR_ENABLED`              | Enable the embedded garbage collector                             | `true`                  |
-| `KOMMODITY_GARBAGE_COLLECTOR_WORKERS`              | Number of garbage collector workers                               | `5`                     |
-| `KOMMODITY_GARBAGE_COLLECTOR_SYNC_PERIOD`          | Resync period for the garbage collector                           | `30s`                   |
-| `KOMMODITY_GARBAGE_COLLECTOR_INITIAL_SYNC_TIMEOUT` | Timeout waiting for initial informer sync                         | `60s`                   |
+The default audit policy is [`pkg/server/audit-policy.yaml`](pkg/server/audit-policy.yaml).
+
+| Variable                                           | Description                                                       | Default                                                      |
+| -------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
+| `KOMMODITY_PORT`                                   | Port for the Kommodity server                                     | `5000`                                                       |
+| `KOMMODITY_BASE_URL`                               | Base URL for the Kommodity server                                 | `http://localhost:5000`                                      |
+| `KOMMODITY_DB_URI`                                 | PostgreSQL connection URI                                         | (none)                                                       |
+| `KOMMODITY_DEVELOPMENT_MODE`                       | Enable development mode                                           | `false`                                                      |
+| `KOMMODITY_INSECURE_DISABLE_AUTHENTICATION`        | Disable authentication for local development                      | `false`                                                      |
+| `KOMMODITY_ADMIN_GROUP`                            | Group name granted cluster-admin equivalence                      | (none)                                                       |
+| `KOMMODITY_OIDC_ISSUER_URL`                        | OIDC issuer URL                                                   | (none)                                                       |
+| `KOMMODITY_OIDC_CLIENT_ID`                         | OIDC client ID                                                    | (none)                                                       |
+| `KOMMODITY_OIDC_USERNAME_CLAIM`                    | OIDC claim used for the username                                  | `email`                                                      |
+| `KOMMODITY_OIDC_GROUPS_CLAIM`                      | OIDC claim used for groups                                        | `groups`                                                     |
+| `KOMMODITY_INFRASTRUCTURE_PROVIDERS`               | Comma-separated providers to enable                               | all                                                          |
+| `KOMMODITY_ATTESTATION_NONCE_TTL`                  | TTL for attestation nonces (e.g. `5m`, `1h`)                      | `5m`                                                         |
+| `KOMMODITY_AUDIT_POLICY_FILE_PATH`                 | Path to a custom Kubernetes audit policy file                     | embedded [`audit-policy.yaml`](pkg/server/audit-policy.yaml) |
+| `KOMMODITY_AUDIT_DISABLED`                         | Disable audit logging entirely                                    | `false`                                                      |
+| `KOMMODITY_TALOS_PROXY_ENABLED`                    | Enable the HTTP CONNECT Talos gRPC proxy                          | `true`                                                       |
+| `KOMMODITY_TALOS_PROXY_PORT`                       | Local listen port for the proxy                                   | `15050`                                                      |
+| `KOMMODITY_TALOS_PROXY_NAMESPACE`                  | Namespace of the talos-cluster-proxy service in workload clusters | `talos-cluster-proxy`                                        |
+| `KOMMODITY_TALOS_PROXY_SERVICE_NAME`               | Name of the talos-cluster-proxy service                           | `talos-cluster-proxy`                                        |
+| `KOMMODITY_TALOS_PROXY_IDLE_TIMEOUT`               | Idle timeout before unused tunnels are closed                     | `1m`                                                         |
+| `KOMMODITY_GARBAGE_COLLECTOR_ENABLED`              | Enable the embedded garbage collector                             | `true`                                                       |
+| `KOMMODITY_GARBAGE_COLLECTOR_WORKERS`              | Number of garbage collector workers                               | `5`                                                          |
+| `KOMMODITY_GARBAGE_COLLECTOR_SYNC_PERIOD`          | Resync period for the garbage collector                           | `30s`                                                        |
+| `KOMMODITY_GARBAGE_COLLECTOR_INITIAL_SYNC_TIMEOUT` | Timeout waiting for initial informer sync                         | `60s`                                                        |
 
 Provider settings are managed in
 [`pkg/provider/providers.yaml`](pkg/provider/providers.yaml): name, repository,

--- a/README.md
+++ b/README.md
@@ -98,11 +98,17 @@ the standard `system:masters`. For local development, set
 
 ### Audit Logging
 
-Native support for the Kubernetes
-[audit policy format](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/).
-Point `KOMMODITY_AUDIT_POLICY_FILE_PATH` at a policy file and every API request
-is captured with user, source IP, timestamp, and (optionally) request/response
-bodies.
+Audit logging is **enabled by default** using an embedded
+[Kubernetes audit policy](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/).
+Every API request is captured with user, source IP, timestamp, and (optionally)
+request/response bodies. Audit events are written to stdout as structured JSON,
+which is picked up by your container platform's log aggregator.
+
+The default policy logs `RequestResponse` for writes to core, RBAC, and Cluster
+API resources, `Metadata` for everything else, and suppresses health probes and
+kubelet lease heartbeats. Override by pointing `KOMMODITY_AUDIT_POLICY_FILE_PATH`
+at a custom policy file, or disable entirely with
+`KOMMODITY_AUDIT_DISABLED=true`.
 
 ### Hardware-Rooted Machine Trust
 
@@ -414,7 +420,8 @@ Kommodity is configured via environment variables.
 | `KOMMODITY_OIDC_GROUPS_CLAIM`                      | OIDC claim used for groups                                        | `groups`                |
 | `KOMMODITY_INFRASTRUCTURE_PROVIDERS`               | Comma-separated providers to enable                               | all                     |
 | `KOMMODITY_ATTESTATION_NONCE_TTL`                  | TTL for attestation nonces (e.g. `5m`, `1h`)                      | `5m`                    |
-| `KOMMODITY_AUDIT_POLICY_FILE_PATH`                 | Path to a Kubernetes audit policy file                            | (none)                  |
+| `KOMMODITY_AUDIT_POLICY_FILE_PATH`                 | Path to a custom Kubernetes audit policy file                     | embedded default        |
+| `KOMMODITY_AUDIT_DISABLED`                         | Disable audit logging entirely                                    | `false`                 |
 | `KOMMODITY_TALOS_PROXY_ENABLED`                    | Enable the HTTP CONNECT Talos gRPC proxy                          | `true`                  |
 | `KOMMODITY_TALOS_PROXY_PORT`                       | Local listen port for the proxy                                   | `15050`                 |
 | `KOMMODITY_TALOS_PROXY_NAMESPACE`                  | Namespace of the talos-cluster-proxy service in workload clusters | `talos-cluster-proxy`   |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ const (
 	envKineURI                            = "KOMMODITY_KINE_URI"
 	envInfrastructureProviders            = "KOMMODITY_INFRASTRUCTURE_PROVIDERS"
 	envAuditPolicyFilePath                = "KOMMODITY_AUDIT_POLICY_FILE_PATH"
+	envAuditDisabled                      = "KOMMODITY_AUDIT_DISABLED"
 	envGarbageCollectorEnabled            = "KOMMODITY_GARBAGE_COLLECTOR_ENABLED"
 	envGarbageCollectorWorkers            = "KOMMODITY_GARBAGE_COLLECTOR_WORKERS"
 	envGarbageCollectorSyncPeriod         = "KOMMODITY_GARBAGE_COLLECTOR_SYNC_PERIOD"
@@ -66,6 +67,7 @@ const (
 	defaultGarbageCollectorSyncPeriod         = 30 * time.Second
 	defaultGarbageCollectorInitialSyncTimeout = 60 * time.Second
 	defaultAzureDefaultCredentialSecret       = ""
+	defaultAuditDisabled                       = false
 	// defaultAzureARMDeletionGracePeriod bounds how long the embedded ARM
 	// reconciler waits for Azure to actually delete a managed resource before it
 	// releases its finalizer. This prevents a single un-deletable resource from
@@ -92,6 +94,7 @@ type KommodityConfig struct {
 	TalosProxyConfig        *TalosProxyConfig
 	GarbageCollectorConfig  *GarbageCollectorConfig
 	AuditPolicyFilePath     string
+	AuditDisabled           bool
 	DevelopmentMode         bool
 	InfrastructureProviders []Provider
 	AzureConfig             *AzureConfig
@@ -187,6 +190,7 @@ func LoadConfig(ctx context.Context) (*KommodityConfig, error) {
 		KineURI:             kineURI,
 		AttestationConfig:   getAttestationConfig(ctx),
 		AuditPolicyFilePath: getAuditPolicyFilePath(ctx),
+		AuditDisabled:       getAuditDisabled(ctx),
 		AuthConfig: &AuthConfig{
 			Apply:      apply,
 			OIDCConfig: oidcConfig,
@@ -513,6 +517,31 @@ func getAuditPolicyFilePath(ctx context.Context) string {
 	}
 
 	return policyFilePath
+}
+
+func getAuditDisabled(ctx context.Context) bool {
+	logger := logging.FromContext(ctx)
+
+	disabled := os.Getenv(envAuditDisabled)
+	if disabled == "" {
+		logger.Info(configurationNotSpecified,
+			zap.String("envVar", envAuditDisabled),
+			zap.Bool("default", defaultAuditDisabled))
+
+		return defaultAuditDisabled
+	}
+
+	disabledBool, err := strconv.ParseBool(disabled)
+	if err != nil {
+		logger.Info("failed to convert audit disabled to boolean",
+			zap.String("envVar", envAuditDisabled),
+			zap.String("value", disabled),
+			zap.Bool("default", defaultAuditDisabled))
+
+		return defaultAuditDisabled
+	}
+
+	return disabledBool
 }
 
 func getTalosProxyConfig(ctx context.Context) *TalosProxyConfig {

--- a/pkg/server/audit-policy.yaml
+++ b/pkg/server/audit-policy.yaml
@@ -24,6 +24,12 @@ rules:
       - group: "coordination.k8s.io"
         resources: ["leases"]
 
+  # Downgrade Secrets to Metadata — never log credential bodies.
+  - level: Metadata
+    resources:
+      - group: ""
+        resources: ["secrets"]
+
   # Log full request AND response bodies for writes to core, RBAC, and CAPI resources.
   - level: RequestResponse
     verbs: ["create", "update", "patch", "delete"]

--- a/pkg/server/audit-policy.yaml
+++ b/pkg/server/audit-policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+# Default Kubernetes audit policy for Kommodity.
+#
+# Audit is ON by default. Override by setting KOMMODITY_AUDIT_POLICY_FILE_PATH
+# to a custom policy file, or disable entirely with KOMMODITY_AUDIT_DISABLED=true.
+#
+# Levels (low to high verbosity): None, Metadata, Request, RequestResponse
+rules:
+  # Don't log health probes, metrics, or streaming reads — high frequency, no forensic value.
+  - level: None
+    verbs: ["get", "list", "watch"]
+    nonResourceURLs:
+      - /healthz*
+      - /readyz*
+      - /livez
+      - /metrics
+
+  # Don't log kubelet lease heartbeats.
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get", "create", "patch", "update"]
+    resources:
+      - group: "coordination.k8s.io"
+        resources: ["leases"]
+
+  # Log full request AND response bodies for writes to core, RBAC, and CAPI resources.
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: ""
+      - group: "rbac.authorization.k8s.io"
+      - group: "cluster.x-k8s.io"
+      - group: "infrastructure.cluster.x-k8s.io"
+      - group: "bootstrap.cluster.x-k8s.io"
+
+  # Metadata-only catch-all for everything else: who, what, when, where.
+  - level: Metadata

--- a/pkg/server/audit.go
+++ b/pkg/server/audit.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strings"
 	"time"
@@ -9,12 +10,19 @@ import (
 	"github.com/kommodity-io/kommodity/pkg/config"
 	"github.com/kommodity-io/kommodity/pkg/logging"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/audit/policy"
 	pluginbuffered "k8s.io/apiserver/plugin/pkg/audit/buffered"
 	pluginlog "k8s.io/apiserver/plugin/pkg/audit/log"
 )
+
+// defaultAuditPolicy is the embedded audit policy used when no custom policy
+// file is provided via KOMMODITY_AUDIT_POLICY_FILE_PATH.
+//
+//go:embed audit-policy.yaml
+var defaultAuditPolicy []byte
 
 // zapWriter adapts a zap.Logger to io.Writer.
 type zapWriter struct {
@@ -29,28 +37,41 @@ func (w zapWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// loadPolicyRuleEvaluator builds the audit policy rule evaluator based on configuration.
+// Precedence: disabled > custom file path > embedded default policy.
 func loadPolicyRuleEvaluator(cfg *config.KommodityConfig) (audit.PolicyRuleEvaluator, error) {
-	policyFilePath := cfg.AuditPolicyFilePath
-	if policyFilePath == "" {
-		// No audit policy file path provided; return nil to use default behavior
+	if cfg.AuditDisabled {
+		// Audit disabled; return nil to skip audit entirely.
 		//
-		//nolint:nilnil
+		//nolint:nilnil // intentional: nil evaluator signals no audit
 		return nil, nil
 	}
 
-	auditPolicy, err := policy.LoadPolicyFromFile(policyFilePath)
+	policyFilePath := cfg.AuditPolicyFilePath
+	if policyFilePath != "" {
+		auditPolicy, err := policy.LoadPolicyFromFile(policyFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load audit policy from file: %w", err)
+		}
+
+		return policy.NewPolicyRuleEvaluator(auditPolicy), nil
+	}
+
+	auditPolicy, err := policy.LoadPolicyFromBytes(defaultAuditPolicy)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load audit policy from file: %w", err)
+		return nil, fmt.Errorf("failed to load embedded audit policy: %w", err)
 	}
 
 	return policy.NewPolicyRuleEvaluator(auditPolicy), nil
 }
 
 func getPolicyBackend(ctx context.Context) audit.Backend {
-	logger := logging.FromContext(ctx)
+	// Create a dedicated audit logger at Info level, independent of the global
+	// LOG_LEVEL setting. Audit events must always be captured for compliance.
+	auditLogger := newAuditLogger(ctx)
 
 	logBackend := pluginlog.NewBackend(
-		zapWriter{logger: logger},
+		zapWriter{logger: auditLogger},
 		pluginlog.FormatJson,
 		auditv1.SchemeGroupVersion)
 
@@ -61,4 +82,20 @@ func getPolicyBackend(ctx context.Context) audit.Backend {
 		MaxBatchWait:   10 * time.Second,
 		BufferSize:     1000,
 	})
+}
+
+// newAuditLogger creates a production zap.Logger pinned to Info level so audit
+// events are never silenced by a higher global LOG_LEVEL.
+func newAuditLogger(ctx context.Context) *zap.Logger {
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+
+	logger, err := config.Build()
+	if err != nil {
+		// Fall back to the standard logger from context if construction fails.
+		return logging.FromContext(ctx)
+	}
+
+	return logger
 }

--- a/pkg/server/audit.go
+++ b/pkg/server/audit.go
@@ -85,11 +85,14 @@ func getPolicyBackend(ctx context.Context) audit.Backend {
 }
 
 // newAuditLogger creates a production zap.Logger pinned to Info level so audit
-// events are never silenced by a higher global LOG_LEVEL.
+// events are never silenced by a higher global LOG_LEVEL. Output goes to stdout
+// and sampling is disabled to ensure no audit events are dropped under load.
 func newAuditLogger(ctx context.Context) *zap.Logger {
 	config := zap.NewProductionConfig()
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	config.OutputPaths = []string{"stdout"}
+	config.Sampling = nil
 
 	logger, err := config.Build()
 	if err != nil {

--- a/pkg/server/audit_test.go
+++ b/pkg/server/audit_test.go
@@ -1,0 +1,82 @@
+//nolint:testpackage // white-box tests exercise unexported audit helpers
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kommodity-io/kommodity/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/audit/policy"
+)
+
+// TestLoadPolicyRuleEvaluatorDisabled asserts that audit is fully disabled when
+// AuditDisabled is true, regardless of other settings.
+func TestLoadPolicyRuleEvaluatorDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.KommodityConfig{
+		AuditDisabled: true,
+		// Even with a path set, disabled should win.
+		AuditPolicyFilePath: "/nonexistent/path.yaml",
+	}
+
+	evaluator, err := loadPolicyRuleEvaluator(cfg)
+	require.NoError(t, err)
+	assert.Nil(t, evaluator, "expected nil evaluator when audit is disabled")
+}
+
+// TestLoadPolicyRuleEvaluatorCustomPath asserts that a custom policy file is
+// loaded when AuditPolicyFilePath is set and audit is not disabled.
+func TestLoadPolicyRuleEvaluatorCustomPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "audit-policy.yaml")
+
+	policyContent := `apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata
+`
+	err := os.WriteFile(policyPath, []byte(policyContent), 0o600)
+	require.NoError(t, err)
+
+	cfg := &config.KommodityConfig{
+		AuditDisabled:       false,
+		AuditPolicyFilePath: policyPath,
+	}
+
+	evaluator, err := loadPolicyRuleEvaluator(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, evaluator, "expected non-nil evaluator for custom policy file")
+}
+
+// TestLoadPolicyRuleEvaluatorEmbedded asserts that the embedded default policy
+// is loaded when no custom path is provided and audit is not disabled.
+func TestLoadPolicyRuleEvaluatorEmbedded(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.KommodityConfig{
+		AuditDisabled:       false,
+		AuditPolicyFilePath: "",
+	}
+
+	evaluator, err := loadPolicyRuleEvaluator(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, evaluator, "expected non-nil evaluator for embedded default policy")
+}
+
+// TestEmbeddedAuditPolicyIsValid asserts the embedded audit-policy.yaml parses
+// successfully and contains at least one rule. This catches malformed YAML at
+// test time rather than at startup.
+func TestEmbeddedAuditPolicyIsValid(t *testing.T) {
+	t.Parallel()
+
+	auditPolicy, err := policy.LoadPolicyFromBytes(defaultAuditPolicy)
+	require.NoError(t, err, "embedded audit policy should parse without error")
+	require.NotNil(t, auditPolicy, "embedded audit policy should not be nil")
+	assert.NotEmpty(t, auditPolicy.Rules, "embedded audit policy should contain at least one rule")
+}


### PR DESCRIPTION
Audit logging is now enabled by default using an embedded Kubernetes audit
policy. The default policy logs RequestResponse for writes to core, RBAC,
and Cluster API resources, Metadata for everything else, and suppresses
health probes and kubelet lease heartbeats.

Three-state precedence: KOMMODITY_AUDIT_DISABLED > KOMMODITY_AUDIT_POLICY_FILE_PATH
> embedded default. A dedicated audit logger pinned to Info level ensures
audit events are never silenced by the global LOG_LEVEL setting.

Resolves PLA-4939

Signed-off-by: Paul Thuriot <pth@corti.ai>
