### PR TITLE
feat(kommodity-cluster): add instanceVolumes for instance-local disks

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.2
+version: 0.26.3
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -188,6 +188,9 @@ Any values that should trigger a new Talos config template when changed should b
 {{- with (dig "additionalVolumes" "" .poolValues) -}}
 	{{- $_ := set $data "additionalVolumes" . -}}
 {{- end -}}
+{{- with (dig "instanceVolumes" "" .poolValues) -}}
+	{{- $_ := set $data "instanceVolumes" . -}}
+{{- end -}}
 {{- toJson $data | sha256sum | trunc 6 -}}
 {{- end -}}
 

--- a/charts/kommodity-cluster/templates/talos/configtemplate.yaml
+++ b/charts/kommodity-cluster/templates/talos/configtemplate.yaml
@@ -22,7 +22,7 @@ spec:
         "installer" $.Values.talos.installer
         "logLevel" $.Values.kommodity.logLevel
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled }}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled (gt (len (default list $np.instanceVolumes)) 0) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- if not (empty $mergedPatch) }}
@@ -31,6 +31,12 @@ spec:
       {{- if $.Values.kommodity.kms.enabled }}
       {{- /* VolumeConfig for KMS disk encryption*/}}
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
+      {{- end }}
+      {{- if $np.instanceVolumes }}
+      {{- /* UserVolumeConfig for instance-local disks (not cloud-provisioned) */ -}}
+{{- $kmsEndpoint := "" -}}
+{{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
+{{- include "kommodity.talos.instanceVolumes" (dict "instanceVolumes" $np.instanceVolumes "kmsEndpoint" $kmsEndpoint "kmsEnabled" $.Values.kommodity.kms.enabled) | nindent 6 }}
       {{- end }}
       {{- if $.Values.kommodity.security.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-attestation extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/controlplane.yaml
+++ b/charts/kommodity-cluster/templates/talos/controlplane.yaml
@@ -62,7 +62,7 @@ spec:
         "disableCNI" $.Values.talos.disableCNI
         "disableProxy" $.Values.talos.disableKubeProxy
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled }}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled (gt (len (default list $.Values.kommodity.controlplane.instanceVolumes)) 0) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- /* Merged MachineConfig patch (labels, taints, annotations, env, installer, OIDC, CNI, proxy, CCM, user patches) */ -}}
@@ -72,6 +72,12 @@ spec:
       {{- if $.Values.kommodity.kms.enabled }}
       {{- /* VolumeConfig for disk encryption (Talos v1.12+) */ -}}
 {{- include "kommodity.talos.volumeEncryption" (dict "endpoint" $.Values.kommodity.kms.endpoint) | nindent 6 }}
+      {{- end }}
+      {{- if $.Values.kommodity.controlplane.instanceVolumes }}
+      {{- /* UserVolumeConfig for instance-local disks (not cloud-provisioned) */ -}}
+{{- $kmsEndpoint := "" -}}
+{{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
+{{- include "kommodity.talos.instanceVolumes" (dict "instanceVolumes" $.Values.kommodity.controlplane.instanceVolumes "kmsEndpoint" $kmsEndpoint "kmsEnabled" $.Values.kommodity.kms.enabled) | nindent 6 }}
       {{- end }}
       {{- if or (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-autobootstrap extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/instance-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/instance-volumes.yaml
@@ -1,0 +1,109 @@
+{{/*
+Talos UserVolumeConfig documents for instance-local volumes — disks that
+are physically attached to the VM by the hypervisor but NOT provisioned via
+the cloud provider's volume API (e.g. Scaleway H100 scratch NVMe, Azure temp
+disk). These disks exist on the instance at boot and need only Talos-side
+partitioning, formatting, and mounting.
+
+Unlike additionalVolumes (which triggers cloud-provider provisioning),
+instanceVolumes emits UserVolumeConfig only — no changes to
+ScalewayMachineTemplate / AzureMachineTemplate.
+
+Each entry supports:
+  - nameSuffix (required): Talos volume name, mounted at /var/mnt/<nameSuffix>
+  - diskSelector (required): CEL expression matching the target disk.
+  - grow (optional, default false): grow to fill disk on subsequent boots
+  - minSize (optional): minimum partition size
+  - maxSize (optional): maximum partition size
+  - encryption (optional):
+      provider: luks2
+      keySource: nodeID or kms (default: kms when kommodity.kms.enabled, else nodeID)
+      lockToState: true (recommended)
+
+### diskSelector
+
+A CEL expression evaluated against each available disk on the node.
+The first disk that returns true is selected. Use `talosctl get disks -o yaml`
+on a running node to see available fields:
+
+  dev_path: /dev/sdb
+  size: 2929688576
+  pretty_size: 2.9 TB
+  io_size: 512
+  sector_size: 512
+  readonly: false
+  model: scratch
+  transport: scsi
+  wwid: ...
+  serial: ...
+  bus_path: /pci0000:00/...
+
+Common selectors:
+  disk.model == 'scratch'                      # Scaleway H100 scratch NVMe
+  disk.transport == 'nvme'                     # any NVMe disk
+  disk.transport == 'scsi' && disk.size > 2u * TiB  # SCSI disk larger than 2 TB
+  disk.serial.startsWith('deadbeef')           # by serial prefix
+  '/dev/disk/by-path/pci-0000:00:1f.2' in disk.symlinks  # by stable symlink
+
+Size constants: KiB, MiB, GiB, TiB, PiB, EiB (binary) or kB, MB, GB, TB, PB, EB (decimal).
+Use `u` suffix for unsigned integers: disk.size > 2u * TiB.
+
+See: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
+
+When KMS is enabled and keySource is "kms" (the default when KMS is enabled),
+the volume is encrypted with luks2+KMS matching STATE/EPHEMERAL. When
+keySource is "nodeID" (the default when KMS is disabled), the volume is
+encrypted with luks2+nodeID, matching the encryption method used by
+STATE/EPHEMERAL on clusters without KMS.
+
+See:
+  - UserVolumeConfig: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+  - Disk encryption:  https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+
+Usage: {{ include "kommodity.talos.instanceVolumes" (dict "instanceVolumes" .instanceVolumes "kmsEndpoint" .kmsEndpoint) }}
+Returns empty string when instanceVolumes is not set or empty.
+*/}}
+{{- define "kommodity.talos.instanceVolumes" -}}
+{{- $volumes := .instanceVolumes -}}
+{{- $kmsEndpoint := .kmsEndpoint -}}
+{{- $kmsEnabled := default false .kmsEnabled -}}
+{{- if $volumes -}}
+{{- range $vol := $volumes }}
+{{- $name := required "instanceVolumes[].nameSuffix is required (used as Talos volume name and /var/mnt/<name> mount path)" $vol.nameSuffix -}}
+{{- $selector := required "instanceVolumes[].diskSelector is required (CEL expression to match the target disk)" $vol.diskSelector -}}
+{{- $enc := default dict (dig "encryption" nil $vol) -}}
+{{- $encProvider := default "luks2" (dig "provider" "" $enc) -}}
+{{- $keySource := default (ternary "kms" "nodeID" $kmsEnabled) (dig "keySource" "" $enc) -}}
+- |
+  apiVersion: v1alpha1
+  kind: UserVolumeConfig
+  name: {{ $name }}
+  provisioning:
+    diskSelector:
+      match: {{ $selector | quote }}
+{{- with $vol.minSize }}
+    minSize: {{ . }}
+{{- end }}
+{{- with $vol.maxSize }}
+    maxSize: {{ . }}
+{{- end }}
+    grow: {{ $vol.grow | default false }}
+{{- if $enc }}
+  encryption:
+    provider: {{ $encProvider }}
+    keys:
+      - slot: 0
+{{- if eq $keySource "kms" }}
+{{- $endpoint := required "kms.endpoint is required when encryption.keySource is kms" $kmsEndpoint -}}
+        kms:
+          endpoint: {{ $endpoint | quote }}
+{{- else }}
+        nodeID: {}
+{{- end }}
+{{- with $enc.lockToState }}
+        lockToState: {{ . }}
+{{- end }}
+{{- end }}
+{{ end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -308,3 +308,153 @@ tests:
       - equal:
           path: spec.version
           value: "controlplane-kubernetes-version"
+
+  # InstanceVolumes tests
+  - it: should emit UserVolumeConfig for worker instanceVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+          grow: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "name: scratch"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "grow: true"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "disk.model == 'scratch'"
+
+  - it: should emit UserVolumeConfig for controlplane instanceVolumes
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.controlplane.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+    asserts:
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "name: scratch"
+
+  - it: should emit multiple UserVolumeConfig for multiple instanceVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+        - nameSuffix: cache
+          diskSelector: "disk.transport == 'nvme'"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "name: scratch"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[2]
+          pattern: "name: cache"
+
+  - it: should not emit UserVolumeConfig when instanceVolumes is unset
+    template: templates/talos/configtemplate.yaml
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[0]
+          pattern: "UserVolumeConfig"
+
+  - it: should emit nodeID encryption by default on instanceVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+          encryption:
+            provider: luks2
+            lockToState: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "provider: luks2"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "nodeID"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "lockToState: true"
+
+  - it: should default to KMS encryption when kms is enabled and keySource is omitted
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.kms.enabled: true
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+          encryption:
+            provider: luks2
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "provider: luks2"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "endpoint: \"https://kms.example.com\""
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "nodeID"
+
+  - it: should use nodeID encryption when kms is enabled but keySource is explicitly nodeID
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.kms.enabled: true
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+          encryption:
+            provider: luks2
+            keySource: nodeID
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "nodeID"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "kms:"
+
+  - it: should not emit encryption when encryption block is omitted
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "luks2"
+
+  - it: should fail when nameSuffix is missing from instanceVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - diskSelector: "disk.model == 'scratch'"
+    asserts:
+      - failedTemplate:
+          errorMessage: "instanceVolumes[].nameSuffix is required (used as Talos volume name and /var/mnt/<name> mount path)"
+
+  - it: should fail when diskSelector is missing from instanceVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+    asserts:
+      - failedTemplate:
+          errorMessage: "instanceVolumes[].diskSelector is required (CEL expression to match the target disk)"

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -192,6 +192,10 @@ kommodity:
         size: 30
         # Azure disk types: Standard_LRS, Premium_LRS, StandardSSD_LRS, UltraSSD_LRS
         type: Premium_LRS
+    # instanceVolumes:
+    #   # Instance-local disks (see values.yaml for full documentation)
+    #   - nameSuffix: scratch
+    #     diskSelector: "disk.transport == 'nvme'"
     healthCheck:
       enabled: true
       unhealthyConditions:
@@ -226,6 +230,19 @@ kommodity:
       #     lun: 0
       #     storageClassName: Premium_LRS
       #     cachingType: ReadWrite
+      # instanceVolumes:
+      #   # Instance-local disks that exist on the VM at boot (not provisioned via
+      #   # the Azure API). E.g. the temp disk on Azure VMs (/dev/sdb on many
+      #   # VM sizes). Emits UserVolumeConfig only — no AzureMachineTemplate changes.
+      #   # diskSelector is a CEL expression — run `talosctl get disks -o yaml`
+      #   # on a node to see available fields (model, transport, size, wwid, etc.).
+      #   - nameSuffix: scratch
+      #     diskSelector: "disk.transport == 'nvme'"
+      #     grow: true
+      #     encryption:
+      #       provider: luks2
+      #       keySource: nodeID  # or kms (default: kms if kommodity.kms.enabled, else nodeID)
+      #       lockToState: true
       labels:
         my-label: my-value
       annotations:

--- a/charts/kommodity-cluster/values.scaleway.yaml
+++ b/charts/kommodity-cluster/values.scaleway.yaml
@@ -61,6 +61,10 @@ kommodity:
     os:
       disk:
         size: 20
+    # instanceVolumes:
+    #   # Instance-local disks (see values.yaml for full documentation)
+    #   - nameSuffix: scratch
+    #     diskSelector: "disk.model == 'scratch'"
     healthCheck:
       enabled: true
       unhealthyConditions:
@@ -86,6 +90,19 @@ kommodity:
       #   - size: 50 # size in GB
       #     type: block # optional, defaults to block (local, block, scratch)
       #     iops: 5000 # optional, only valid for block volumes (5000 or 15000)
+      # instanceVolumes:
+      #   # Instance-local disks that exist on the VM at boot (not provisioned via
+      #   # the Scaleway API). E.g. the built-in scratch NVMe on H100 instances.
+      #   # Emits UserVolumeConfig only — no ScalewayMachineTemplate changes.
+      #   # diskSelector is a CEL expression — run `talosctl get disks -o yaml`
+      #   # on a node to see available fields (model, transport, size, wwid, etc.).
+      #   - nameSuffix: scratch
+      #     diskSelector: "disk.model == 'scratch'"
+      #     grow: true
+      #     encryption:
+      #       provider: luks2
+      #       keySource: nodeID  # or kms (default: kms if kommodity.kms.enabled, else nodeID)
+      #       lockToState: true
       labels:
         my-label: my-value
       annotations:

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -308,6 +308,23 @@ kommodity:
     #     status: "False"
     #     timeout: 300s
 
+    # instanceVolumes:
+    #   # Instance-local disks that exist on the VM at boot (not provisioned via
+    #   # the cloud provider's volume API). E.g. the Scaleway H100 scratch NVMe
+    #   # or the Azure VM temp disk. Emits UserVolumeConfig only — no changes
+    #   # to ScalewayMachineTemplate / AzureMachineTemplate.
+    #   # diskSelector is a CEL expression — run `talosctl get disks -o yaml`
+    #   # on a node to see available fields (model, transport, size, wwid, etc.).
+    #   - nameSuffix: scratch          # required — Talos volume name, mounted at /var/mnt/<name>
+    #     diskSelector: "disk.model == 'scratch'"  # required — CEL expression
+    #     grow: true                   # optional — grow to fill disk on subsequent boots
+    #     # minSize: 100GB             # optional — minimum partition size
+    #     # maxSize: 200GB             # optional — maximum partition size
+    #     encryption:                   # optional
+    #       provider: luks2
+    #       keySource: nodeID  # or kms (default: kms if kommodity.kms.enabled, else nodeID)
+    #       lockToState: true
+
   nodepools: {}
     ## Example of nodepool configuration
     # default:
@@ -354,6 +371,16 @@ kommodity:
     #     - type: Ready
     #       status: "False"
     #       timeout: 300s
+
+    #   # Instance-local disks (see kommodity.controlplane.instanceVolumes above)
+    #   instanceVolumes:
+    #     - nameSuffix: scratch
+    #       diskSelector: "disk.model == 'scratch'"
+    #       grow: true
+    #       encryption:
+    #         provider: luks2
+    #         keySource: nodeID  # or kms (default: kms if kommodity.kms.enabled, else nodeID)
+    #         lockToState: true
 
   # Logging verbosity: debug, info, warn, error (set as LOG_LEVEL env var)
   logLevel: warn


### PR DESCRIPTION
## Problem

`additionalVolumes` provisions cloud-provider data disks (Azure data disks, Scaleway block volumes) but cannot handle disks that are physically attached to the VM at boot and not provisioned via the cloud API. The main example: Scaleway H100 instances ship with a 2.7 TB NVMe scratch disk (`/dev/sdb`, model `scratch`) that is built into the instance hardware. Adding it to `additionalVolumes` would cause the Scaleway API to provision a *second* volume on top of the built-in one.

## Fix

Add a new `instanceVolumes` field that emits Talos `UserVolumeConfig` documents only — no changes to `ScalewayMachineTemplate` / `AzureMachineTemplate`. This decouples Talos-side volume configuration from cloud-provider provisioning.

### Fields

```yaml
instanceVolumes:
  - nameSuffix: scratch          # required — Talos volume name, mounted at /var/mnt/<name>
    diskSelector: "disk.model == 'scratch'"  # required — CEL expression
    grow: true                    # optional — grow to fill disk
    encryption:                   # optional
      provider: luks2
      keySource: nodeID           # or kms (requires kommodity.kms.enabled)
      lockToState: true
```

### Key design decisions

- **Decoupled from provider templates**: `instanceVolumes` only emits `UserVolumeConfig` strategic patches. No `ScalewayMachineTemplate` / `AzureMachineTemplate` changes.
- **User-specified diskSelector**: Unlike `additionalVolumes` (size-based), `instanceVolumes` requires an explicit CEL expression to target the disk by model, transport, wwid, etc. — no ambiguity.
- **nodeID encryption by default**: Falls back to `nodeID` (same as STATE/EPHEMERAL on non-KMS clusters) when `keySource` is omitted or set to `nodeID`. KMS encryption available when `kommodity.kms.enabled` is true and `keySource: kms` is set.
- **Hash rotation**: `instanceVolumes` added to `talosConfigHash` so config changes trigger new TalosConfigTemplate.

### Files changed

- `templates/talos/instance-volumes.yaml` (new) — `kommodity.talos.instanceVolumes` helper
- `templates/talos/configtemplate.yaml` — include instanceVolumes in worker strategicPatches
- `templates/talos/controlplane.yaml` — include instanceVolumes in CP strategicPatches
- `templates/_helpers.tpl` — add instanceVolumes to talosConfigHash
- `values.scaleway.yaml`, `values.azure.yaml` — document `instanceVolumes`
- `tests/talos_provider_test.yaml` — 10 new tests
- `Chart.yaml` — version bump 0.26.2 → 0.26.3

### Verification

All 212 helm-unittest tests pass (202 existing + 10 new).
