### PR TITLE
fix(kommodity-cluster): fix KMS rendering in instanceVolumes template

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.3
+version: 0.26.4
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/talos/instance-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/instance-volumes.yaml
@@ -94,7 +94,7 @@ Returns empty string when instanceVolumes is not set or empty.
     keys:
       - slot: 0
 {{- if eq $keySource "kms" }}
-{{- $endpoint := required "kms.endpoint is required when encryption.keySource is kms" $kmsEndpoint -}}
+{{- $endpoint := required "kms.endpoint is required when encryption.keySource is kms" $kmsEndpoint }}
         kms:
           endpoint: {{ $endpoint | quote }}
 {{- else }}


### PR DESCRIPTION
## Summary

Fixes a template rendering bug in the `instanceVolumes` KMS encryption path introduced in #428 (chart 0.26.3).

The trailing dash in `{{- $endpoint := ... -}}` on line 97 of `instance-volumes.yaml` consumed the newline before `kms:`, producing `slot: 0kms:` on a single line — invalid YAML.

## Before (broken)

```yaml
encryption:
  provider: luks2
  keys:
    - slot: 0kms:
        endpoint: "https://kommodity.dev.corti.app"
      lockToState: true
```

## After (fixed)

```yaml
encryption:
  provider: luks2
  keys:
    - slot: 0
      kms:
        endpoint: "https://kommodity.dev.corti.app"
      lockToState: true
```

## Reproduction

Render the chart with KMS enabled and instanceVolumes configured:

```bash
helm template test ./charts/kommodity-cluster \
  --set kommodity.kms.enabled=true \
  --set kommodity.kms.endpoint="https://kms.example.com" \
  --set kommodity.nodepools.default.instanceVolumes[0].nameSuffix=scratch \
  --set kommodity.nodepools.default.instanceVolumes[0].diskSelector="disk.model == 'scratch'" \
  --set kommodity.nodepools.default.instanceVolumes[0].encryption.provider=luks2
```

The rendered `UserVolumeConfig` strategic patch contains `slot: 0kms:` which fails YAML parsing.

## Fix

Remove the trailing dash from the trim directive (`{{- ... -}}` → `{{- ... }}`) so the newline and indentation before `kms:` are preserved. Bump chart version to 0.26.4.
