### PR TITLE
feat(libkapi): add WithRBACAuthorizer, a real RBAC-rule-evaluating authorizer

### DIFF
--- a/pkg/libkapi/README.md
+++ b/pkg/libkapi/README.md
@@ -251,6 +251,7 @@ auth-specific alike — pass any combination, in any order.
 | `WithOIDC(cfg OIDCConfig)`                       | Adds an OIDC bearer-token authenticator. Fetches the issuer's discovery document at `IssuerURL/.well-known/openid-configuration` during `New`.                                                         |
 | `WithServiceAccount(cfg ServiceAccountConfig)`   | Adds a ServiceAccount token authenticator and starts the SA token controller (issues tokens for ServiceAccounts). Optionally persists the signing key to a Secret and watches for key rotation.        |
 | `WithAdminAuthorizer(cfg AdminAuthorizerConfig)` | Sets an authorizer that allows health endpoints (anonymous), `system:masters`, any group listed in the configured comma-delimited `AdminGroups`, and `system:serviceaccounts`; denies everything else. |
+| `WithRBACAuthorizer(cfg RBACAuthorizerConfig)`   | Sets an authorizer that evaluates real `Role`/`RoleBinding`/`ClusterRole`/`ClusterRoleBinding` objects via upstream Kubernetes's own RBAC authorizer, falling back to `WithAdminAuthorizer`'s exact behavior whenever no RBAC rule matches. See [RBAC authorizer](#rbac-authorizer). |
 | `WithAuthorizer(a Authorizer)`                   | Sets a custom authorizer. Use this to plug in any `k8s.io/apiserver` authorizer.                                                                                                                       |
 | `WithController(c Controller)`                   | Registers a `Controller` against the server's own privileged loopback identity. See [Controllers](#controllers). Repeatable.                                                                          |
 | `WithLeaderElection(cfg LeaderElectionConfig)`   | Enables manager-wide leader election via a `coordination.k8s.io` `Lease`. See [Controllers](#controllers).                                                                                             |
@@ -293,13 +294,54 @@ auth-specific alike — pass any combination, in any order.
 | `TokenSecretsNamespace` | `"kube-system"` | Namespace where SA token secrets are listed for rotation.                                                                            |
 | `OnTokenRotated`        | nil             | Callback called for each SA token secret rotated during key rotation. Use this for side effects like updating autoscaler ConfigMaps. |
 
+#### RBAC authorizer
+
+`WithRBACAuthorizer` is `WithAdminAuthorizer` plus real RBAC rule
+evaluation: it tries upstream Kubernetes's own RBAC authorizer first —
+reading `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding`
+objects through informer-backed listers, so `kubectl auth can-i` reflects
+whatever those objects actually say — and falls back to exactly
+`WithAdminAuthorizer`'s behavior (`system:masters`, `AdminGroups`,
+`system:serviceaccounts`, health endpoints) whenever no RBAC rule matches.
+This ordering is safe because upstream's RBAC authorizer only ever returns
+Allow or NoOpinion for a request, never a terminal Deny — RBAC is purely
+additive.
+
+```go
+server, err := libkapi.New(ctx,
+    libkapi.WithStorage("sqlite://local.db"),
+    libkapi.WithOIDC(libkapi.OIDCConfig{IssuerURL: "https://accounts.google.com", ClientID: "my-client"}),
+    libkapi.WithRBACAuthorizer(libkapi.RBACAuthorizerConfig{
+        // Deny-by-default fallback, same format as AdminAuthorizerConfig.AdminGroups.
+        AdminGroups: "my-admin-group,my-other-admin-group",
+    }),
+)
+```
+
+`RBACAuthorizerConfig` fields:
+
+| Field         | Default    | Description                                                                                                                  |
+| ------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `AdminGroups` | (required) | Comma-delimited fallback admin groups — same format as `AdminAuthorizerConfig.AdminGroups`. At least one group is required. |
+
+The RBAC authorizer's listers read from a `SharedInformerFactory` that only
+exists once the server's own `LoopbackClientConfig` is available — a
+chicken-and-egg `WithAuthorizer` itself doesn't have to solve, since
+`WithRBACAuthorizer` handles it internally: the returned authorizer starts
+with no listers installed, and `New` finishes wiring them up synchronously,
+entirely before `ListenAndServe` is ever called, so no real request can
+reach the authorizer before it's ready. It deliberately doesn't make a
+direct API call per Authorize check (informer listers instead) — a direct
+call would need the very authorization decision it's trying to compute,
+recursively, since the client it would call through is this same server.
+
 #### Security posture
 
-| Options passed                                          | Authenticator                            | Authorizer                    |
-| ------------------------------------------------------- | ---------------------------------------- | ----------------------------- |
-| None                                                    | anonymous                                | always-allow                  |
-| Auth options, no `WithAuthorizer`/`WithAdminAuthorizer` | union of strategies + anonymous fallback | always-allow (logged warning) |
-| Auth options + `WithAuthorizer`/`WithAdminAuthorizer`   | union of strategies + anonymous fallback | caller's authorizer           |
+| Options passed                                                              | Authenticator                            | Authorizer                    |
+| ----------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------ |
+| None                                                                        | anonymous                                | always-allow                  |
+| Auth options, no `WithAuthorizer`/`WithAdminAuthorizer`/`WithRBACAuthorizer` | union of strategies + anonymous fallback | always-allow (logged warning) |
+| Auth options + `WithAuthorizer`/`WithAdminAuthorizer`/`WithRBACAuthorizer`   | union of strategies + anonymous fallback | caller's authorizer           |
 
 ### Controllers
 
@@ -539,5 +581,5 @@ was never called.
 | `ErrNotImplemented`              | `WithTLS` is used.                                                                                                |
 | `ErrOIDCIssuerRequired`          | `WithOIDC` is called with an empty `IssuerURL`.                                                                   |
 | `ErrOIDCClientIDRequired`        | `WithOIDC` is called with an empty `ClientID`.                                                                    |
-| `ErrAdminGroupRequired`          | `WithAdminAuthorizer` is called with an `AdminGroups` that contains no non-empty group after splitting on commas. |
+| `ErrAdminGroupRequired`          | `WithAdminAuthorizer` or `WithRBACAuthorizer` is called with an `AdminGroups` that contains no non-empty group after splitting on commas. |
 | `ErrLeaderElectionIDRequired`    | `WithLeaderElection` is called with an empty `ID`.                                                                |

--- a/pkg/libkapi/auth/admin.go
+++ b/pkg/libkapi/auth/admin.go
@@ -33,6 +33,13 @@ type AdminAuthorizerConfig struct {
 // system:serviceaccounts; denies everything else.
 //
 // Mirrors pkg/server/auth.go's adminAuthorizer (lines 107-152).
+//
+// Clears any RBACListerSource a preceding WithRBACAuthorizer installed:
+// options are applied in order with the last authorizer-setting call
+// winning (see WithAuthorizer's doc), and a stale RBACListerSource left in
+// place would still make buildServer's finishRBACAuthorizer wire up and
+// start RBAC informers for listers nothing reads anymore — wasted watches
+// and API load for no effect on the actual, overwritten authorizer.
 func WithAdminAuthorizer(adminCfg AdminAuthorizerConfig) Option {
 	return func(_ context.Context, cfg *config) error {
 		groups := parseAdminGroups(adminCfg.AdminGroups)
@@ -41,6 +48,7 @@ func WithAdminAuthorizer(adminCfg AdminAuthorizerConfig) Option {
 		}
 
 		cfg.authorizer = &AdminAuthorizer{Groups: groups}
+		cfg.rbacListerSource = nil
 
 		return nil
 	}

--- a/pkg/libkapi/auth/helpers_test.go
+++ b/pkg/libkapi/auth/helpers_test.go
@@ -50,6 +50,7 @@ type fakeAttributes struct {
 	resource   string
 	verb       string
 	namespace  string
+	apiGroup   string
 }
 
 func (a *fakeAttributes) GetUser() user.Info { return a.user }
@@ -62,7 +63,7 @@ func (a *fakeAttributes) GetNamespace() string                           { retur
 func (a *fakeAttributes) GetResource() string                            { return a.resource }
 func (a *fakeAttributes) GetSubresource() string                         { return "" }
 func (a *fakeAttributes) GetName() string                                { return "" }
-func (a *fakeAttributes) GetAPIGroup() string                            { return "" }
+func (a *fakeAttributes) GetAPIGroup() string                            { return a.apiGroup }
 func (a *fakeAttributes) GetAPIVersion() string                          { return "" }
 func (a *fakeAttributes) IsResourceRequest() bool                        { return a.isResource }
 func (a *fakeAttributes) GetPath() string                                { return a.path }

--- a/pkg/libkapi/auth/options.go
+++ b/pkg/libkapi/auth/options.go
@@ -20,6 +20,7 @@ type config struct {
 	saConfig          *ServiceAccountConfig
 	authorizer        authorizer.Authorizer
 	apiAudiences      authenticator.Audiences
+	rbacListerSource  *RBACListerSource
 }
 
 // ResolvedConfig is the resolved authentication/authorization state, ready
@@ -43,6 +44,13 @@ type ResolvedConfig struct {
 	// APIAudiences is the resolved API audiences for token validation.
 	// Empty if none were set.
 	APIAudiences authenticator.Audiences
+
+	// RBACListerSource is non-nil if WithRBACAuthorizer was used. It has no
+	// listers installed yet — buildServer calls SetListers on it once the
+	// server's SharedInformerFactory is available, the same "config now,
+	// finish later" split SAConfig uses for BuildSAAuthenticator. See
+	// WithRBACAuthorizer's doc for why the listers can't be built here.
+	RBACListerSource *RBACListerSource
 }
 
 // Resolve applies all options in order and returns the resolved configuration.
@@ -61,6 +69,7 @@ func Resolve(ctx context.Context, opts []Option, logger *slog.Logger) (*Resolved
 		SAConfig:          cfg.saConfig,
 		Authorizer:        resolveAuthorizer(cfg, logger),
 		APIAudiences:      cfg.apiAudiences,
+		RBACListerSource:  cfg.rbacListerSource,
 	}, nil
 }
 

--- a/pkg/libkapi/auth/options.go
+++ b/pkg/libkapi/auth/options.go
@@ -117,6 +117,13 @@ func BuildUnionAuthenticator(oidcAuth authenticator.Request, saAuth authenticato
 
 // WithAuthorizer sets a custom authorizer. If not called, the server uses
 // always-allow (with a warning if authentication strategies are configured).
+//
+// Options are applied in order, with the last authorizer-setting call
+// (WithAuthorizer, WithAdminAuthorizer, or WithRBACAuthorizer) winning —
+// so this also clears any RBACListerSource a preceding WithRBACAuthorizer
+// installed. Leaving it in place would still make buildServer's
+// finishRBACAuthorizer wire up and start RBAC informers for listers
+// nothing reads anymore, since authz here doesn't reference them.
 func WithAuthorizer(authz authorizer.Authorizer) Option {
 	return func(_ context.Context, cfg *config) error {
 		if authz == nil {
@@ -124,6 +131,7 @@ func WithAuthorizer(authz authorizer.Authorizer) Option {
 		}
 
 		cfg.authorizer = authz
+		cfg.rbacListerSource = nil
 
 		return nil
 	}

--- a/pkg/libkapi/auth/options_test.go
+++ b/pkg/libkapi/auth/options_test.go
@@ -59,6 +59,46 @@ func TestResolve_WithAuthorizer_NilReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, auth.ErrAuthorizerNil)
 }
 
+// TestResolve_WithAuthorizer_AfterRBACAuthorizer_ClearsRBACListerSource
+// verifies that a WithAuthorizer call after WithRBACAuthorizer clears
+// RBACListerSource, not just Authorizer — otherwise buildServer's
+// finishRBACAuthorizer would still wire up and start RBAC informers for
+// listers the final (overwritten) authorizer never reads, wasting API
+// server watches for no effect.
+func TestResolve_WithAuthorizer_AfterRBACAuthorizer_ClearsRBACListerSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	customAuthz := authorizerfactory.NewAlwaysAllowAuthorizer()
+
+	resolved, err := auth.Resolve(ctx, []auth.Option{
+		auth.WithRBACAuthorizer(auth.RBACAuthorizerConfig{AdminGroups: "my-admins"}),
+		auth.WithAuthorizer(customAuthz),
+	}, slog.Default())
+	require.NoError(t, err)
+
+	assert.Same(t, customAuthz, resolved.Authorizer)
+	assert.Nil(t, resolved.RBACListerSource)
+}
+
+// TestResolve_WithAdminAuthorizer_AfterRBACAuthorizer_ClearsRBACListerSource
+// is the same regression guard as
+// TestResolve_WithAuthorizer_AfterRBACAuthorizer_ClearsRBACListerSource,
+// for WithAdminAuthorizer instead of WithAuthorizer.
+func TestResolve_WithAdminAuthorizer_AfterRBACAuthorizer_ClearsRBACListerSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	resolved, err := auth.Resolve(ctx, []auth.Option{
+		auth.WithRBACAuthorizer(auth.RBACAuthorizerConfig{AdminGroups: "my-admins"}),
+		auth.WithAdminAuthorizer(auth.AdminAuthorizerConfig{AdminGroups: "my-admins"}),
+	}, slog.Default())
+	require.NoError(t, err)
+
+	assert.Nil(t, resolved.RBACListerSource)
+}
+
 // TestResolve_AuthWithoutAuthorizer_LogsWarning verifies that when
 // authentication strategies are configured but no authorizer is set,
 // Resolve uses always-allow and the logger receives a warning.

--- a/pkg/libkapi/auth/rbac.go
+++ b/pkg/libkapi/auth/rbac.go
@@ -1,0 +1,203 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/authorization/union"
+	rbaclisters "k8s.io/client-go/listers/rbac/v1"
+	upstreamrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
+)
+
+// errRBACListersNotReady is returned by RBACListerSource's Getter/Lister
+// methods before SetListers has been called — see RBACListerSource's doc.
+// In practice this should never be observed: buildServer calls SetListers
+// synchronously during New, before the server ever starts serving, so no
+// Authorize call can reach RBACListerSource before it's ready.
+var errRBACListersNotReady = errors.New("rbac authorizer: informer listers not ready")
+
+// RBACAuthorizerConfig configures the RBAC authorizer.
+type RBACAuthorizerConfig struct {
+	// AdminGroups is a comma-delimited list of groups allowed full access,
+	// used as WithRBACAuthorizer's deny-by-default fallback whenever no
+	// RBAC rule grants access — see WithRBACAuthorizer. Same format as
+	// AdminAuthorizerConfig.AdminGroups. At least one group is required.
+	AdminGroups string
+}
+
+// WithRBACAuthorizer sets an authorizer that evaluates real RBAC rules —
+// Role, RoleBinding, ClusterRole, and ClusterRoleBinding objects, via
+// upstream Kubernetes's own RBAC authorizer — tried first, falling back to
+// the same behavior WithAdminAuthorizer provides (system:masters,
+// AdminGroups, system:serviceaccounts, health paths) whenever no RBAC rule
+// matches.
+//
+// This ordering is safe because upstream's RBAC authorizer only ever
+// returns Allow or NoOpinion for a request, never a terminal Deny — RBAC
+// is purely additive — so every bit of the admin-group authorizer's
+// deny-by-default behavior is preserved exactly, while a real
+// ClusterRoleBinding/RoleBinding also grants access through actual rule
+// evaluation, so `kubectl auth can-i` reflects reality instead of a grant
+// that exists only as an authorizer's in-memory group check.
+//
+// The RBAC half reads Role/RoleBinding/ClusterRole/ClusterRoleBinding
+// objects through informer-backed listers, not a live per-call API
+// request: a direct client would make Authorize itself issue a new
+// request against this same server to decide whether to authorize that
+// very request (to check "is this ClusterRoleBinding list allowed," it
+// would need to list ClusterRoleBindings, which needs authorizing, which
+// needs to list ClusterRoleBindings...) — client-go listers instead read
+// a local, continuously-updated cache that never blocks and never makes a
+// new outbound call from inside Authorize, exactly how upstream
+// kube-apiserver's own RBAC authorizer avoids the same trap.
+//
+// Those listers can't be built until the server's SharedInformerFactory
+// exists, which doesn't happen at Option-application time (it's produced
+// by apiserver.SetupAPIServerConfig, itself called with the resolved
+// authorizer as an argument — the server's privileged identity and its
+// authorizer are resolved in the same step, each needing the other).
+// WithRBACAuthorizer breaks that cycle by installing an RBACListerSource
+// with no listers yet; buildServer calls SetListers on it once the
+// SharedInformerFactory is available (see server.go's
+// finishRBACAuthorizer), synchronously within New, entirely before
+// ListenAndServe is ever called — so there is no window where a real
+// request could reach this authorizer before it's ready. Until the
+// factory's own post-start hook actually starts syncing (registered by
+// finishRBACAuthorizer too), the listers simply read an empty cache — no
+// blocking, no error, just "no matching rule yet," which is exactly the
+// same outcome as no RBAC objects existing at all: NoOpinion, falling
+// through to the admin-group fallback.
+func WithRBACAuthorizer(rbacCfg RBACAuthorizerConfig) Option {
+	return func(_ context.Context, cfg *config) error {
+		groups := parseAdminGroups(rbacCfg.AdminGroups)
+		if len(groups) == 0 {
+			return ErrAdminGroupRequired
+		}
+
+		source := &RBACListerSource{}
+		rbacAuthorizer := upstreamrbac.New(source, source, source, source)
+		adminAuthorizer := &AdminAuthorizer{Groups: groups}
+
+		cfg.authorizer = union.New(rbacAuthorizer, adminAuthorizer)
+		cfg.rbacListerSource = source
+
+		return nil
+	}
+}
+
+// RBACListerSource adapts client-go's rbac/v1 listers, installed later via
+// SetListers, to the RoleGetter/RoleBindingLister/ClusterRoleGetter/
+// ClusterRoleBindingLister interfaces
+// k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac.New expects
+// (k8s.io/kubernetes/pkg/registry/rbac/validation's own interfaces) — see
+// WithRBACAuthorizer's doc for why listers, not a direct client.
+//
+// Every method locks around the same lister fields, so SetListers is safe
+// to call concurrently with Get/List calls arriving from in-flight
+// Authorize checks — though in practice buildServer populates it
+// synchronously during New, before the server ever starts serving, so no
+// such call ever actually races it.
+type RBACListerSource struct {
+	mu                       sync.RWMutex
+	roleLister               rbaclisters.RoleLister
+	roleBindingLister        rbaclisters.RoleBindingLister
+	clusterRoleLister        rbaclisters.ClusterRoleLister
+	clusterRoleBindingLister rbaclisters.ClusterRoleBindingLister
+}
+
+// SetListers installs the four listers, unblocking every Getter/Lister
+// method.
+func (s *RBACListerSource) SetListers(
+	roleLister rbaclisters.RoleLister,
+	roleBindingLister rbaclisters.RoleBindingLister,
+	clusterRoleLister rbaclisters.ClusterRoleLister,
+	clusterRoleBindingLister rbaclisters.ClusterRoleBindingLister,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.roleLister = roleLister
+	s.roleBindingLister = roleBindingLister
+	s.clusterRoleLister = clusterRoleLister
+	s.clusterRoleBindingLister = clusterRoleBindingLister
+}
+
+// GetRole implements
+// k8s.io/kubernetes/pkg/registry/rbac/validation.RoleGetter.
+func (s *RBACListerSource) GetRole(_ context.Context, namespace, name string) (*rbacv1.Role, error) {
+	s.mu.RLock()
+	lister := s.roleLister
+	s.mu.RUnlock()
+
+	if lister == nil {
+		return nil, errRBACListersNotReady
+	}
+
+	role, err := lister.Roles(namespace).Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role %q: %w", name, err)
+	}
+
+	return role, nil
+}
+
+// ListRoleBindings implements
+// k8s.io/kubernetes/pkg/registry/rbac/validation.RoleBindingLister.
+func (s *RBACListerSource) ListRoleBindings(_ context.Context, namespace string) ([]*rbacv1.RoleBinding, error) {
+	s.mu.RLock()
+	lister := s.roleBindingLister
+	s.mu.RUnlock()
+
+	if lister == nil {
+		return nil, errRBACListersNotReady
+	}
+
+	bindings, err := lister.RoleBindings(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list role bindings in %q: %w", namespace, err)
+	}
+
+	return bindings, nil
+}
+
+// GetClusterRole implements
+// k8s.io/kubernetes/pkg/registry/rbac/validation.ClusterRoleGetter.
+func (s *RBACListerSource) GetClusterRole(_ context.Context, name string) (*rbacv1.ClusterRole, error) {
+	s.mu.RLock()
+	lister := s.clusterRoleLister
+	s.mu.RUnlock()
+
+	if lister == nil {
+		return nil, errRBACListersNotReady
+	}
+
+	role, err := lister.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster role %q: %w", name, err)
+	}
+
+	return role, nil
+}
+
+// ListClusterRoleBindings implements
+// k8s.io/kubernetes/pkg/registry/rbac/validation.ClusterRoleBindingLister.
+func (s *RBACListerSource) ListClusterRoleBindings(_ context.Context) ([]*rbacv1.ClusterRoleBinding, error) {
+	s.mu.RLock()
+	lister := s.clusterRoleBindingLister
+	s.mu.RUnlock()
+
+	if lister == nil {
+		return nil, errRBACListersNotReady
+	}
+
+	bindings, err := lister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster role bindings: %w", err)
+	}
+
+	return bindings, nil
+}

--- a/pkg/libkapi/auth/rbac.go
+++ b/pkg/libkapi/auth/rbac.go
@@ -139,7 +139,7 @@ func (s *RBACListerSource) GetRole(_ context.Context, namespace, name string) (*
 
 	role, err := lister.Roles(namespace).Get(name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get role %q: %w", name, err)
+		return nil, fmt.Errorf("failed to get role %q in namespace %q: %w", name, namespace, err)
 	}
 
 	return role, nil

--- a/pkg/libkapi/auth/rbac_test.go
+++ b/pkg/libkapi/auth/rbac_test.go
@@ -1,0 +1,219 @@
+package auth_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/informers"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	rbaclisters "k8s.io/client-go/listers/rbac/v1"
+
+	"github.com/kommodity-io/kommodity/pkg/libkapi/auth"
+)
+
+// TestWithRBACAuthorizer_MissingAdminGroup_ReturnsError verifies that
+// WithRBACAuthorizer returns ErrAdminGroupRequired when AdminGroups is
+// empty — the RBAC half is purely additive, so an empty fallback would
+// mean no deny-by-default backstop at all.
+func TestWithRBACAuthorizer_MissingAdminGroup_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	_, err := auth.Resolve(ctx, []auth.Option{
+		auth.WithRBACAuthorizer(auth.RBACAuthorizerConfig{AdminGroups: ""}),
+	}, slog.Default())
+
+	require.ErrorIs(t, err, auth.ErrAdminGroupRequired)
+}
+
+// TestWithRBACAuthorizer_SetsAuthorizerAndListerSource verifies that
+// WithRBACAuthorizer sets both a non-nil authorizer and a non-nil
+// RBACListerSource on the resolved config — buildServer relies on the
+// latter being present to know whether to call SetListers.
+func TestWithRBACAuthorizer_SetsAuthorizerAndListerSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	resolved, err := auth.Resolve(ctx, []auth.Option{
+		auth.WithRBACAuthorizer(auth.RBACAuthorizerConfig{AdminGroups: "my-admins"}),
+	}, slog.Default())
+	require.NoError(t, err)
+
+	assert.NotNil(t, resolved.Authorizer)
+	assert.NotNil(t, resolved.RBACListerSource)
+}
+
+// TestRBACListerSource_BeforeSetListers_ReturnsError verifies every
+// Getter/Lister method fails before SetListers has been called.
+func TestRBACListerSource_BeforeSetListers_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	source := &auth.RBACListerSource{}
+
+	_, err := source.GetRole(context.Background(), "default", "reader")
+	require.Error(t, err)
+
+	_, err = source.ListRoleBindings(context.Background(), "default")
+	require.Error(t, err)
+
+	_, err = source.GetClusterRole(context.Background(), "reader")
+	require.Error(t, err)
+
+	_, err = source.ListClusterRoleBindings(context.Background())
+	require.Error(t, err)
+}
+
+// newSyncedRBACListers builds client-go rbac/v1 listers backed by a fake
+// clientset, seeded with objects and synced before returning — mirroring
+// what finishRBACAuthorizer installs from a real SharedInformerFactory,
+// but already caught up rather than racing a background Start.
+func newSyncedRBACListers(t *testing.T, objects ...runtime.Object) (
+	rbaclisters.RoleLister, rbaclisters.RoleBindingLister,
+	rbaclisters.ClusterRoleLister, rbaclisters.ClusterRoleBindingLister,
+) {
+	t.Helper()
+
+	fakeClient := fakeclientset.NewClientset(objects...)
+	factory := informers.NewSharedInformerFactory(fakeClient, 0)
+	rbacInformers := factory.Rbac().V1()
+
+	roleLister := rbacInformers.Roles().Lister()
+	roleBindingLister := rbacInformers.RoleBindings().Lister()
+	clusterRoleLister := rbacInformers.ClusterRoles().Lister()
+	clusterRoleBindingLister := rbacInformers.ClusterRoleBindings().Lister()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	factory.Start(ctx.Done())
+
+	synced := factory.WaitForCacheSync(ctx.Done())
+	for typ, ok := range synced {
+		require.Truef(t, ok, "cache for %v never synced", typ)
+	}
+
+	return roleLister, roleBindingLister, clusterRoleLister, clusterRoleBindingLister
+}
+
+// TestRBACListerSource_AfterSetListers_ServesObjects verifies every
+// Getter/Lister method reads through to the installed listers once
+// SetListers has been called.
+func TestRBACListerSource_AfterSetListers_ServesObjects(t *testing.T) {
+	t.Parallel()
+
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "reader", Namespace: "default"}}
+	roleBinding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "readers", Namespace: "default"}}
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "cluster-reader"}}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "cluster-readers"}}
+
+	roleLister, roleBindingLister, clusterRoleLister, clusterRoleBindingLister :=
+		newSyncedRBACListers(t, role, roleBinding, clusterRole, clusterRoleBinding)
+
+	source := &auth.RBACListerSource{}
+	source.SetListers(roleLister, roleBindingLister, clusterRoleLister, clusterRoleBindingLister)
+
+	gotRole, err := source.GetRole(context.Background(), "default", "reader")
+	require.NoError(t, err)
+	assert.Equal(t, "reader", gotRole.Name)
+
+	roleBindings, err := source.ListRoleBindings(context.Background(), "default")
+	require.NoError(t, err)
+	require.Len(t, roleBindings, 1)
+	assert.Equal(t, "readers", roleBindings[0].Name)
+
+	gotClusterRole, err := source.GetClusterRole(context.Background(), "cluster-reader")
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-reader", gotClusterRole.Name)
+
+	clusterRoleBindings, err := source.ListClusterRoleBindings(context.Background())
+	require.NoError(t, err)
+	require.Len(t, clusterRoleBindings, 1)
+	assert.Equal(t, "cluster-readers", clusterRoleBindings[0].Name)
+}
+
+// TestRBACAuthorizer_FallsBackToAdminGroupBeforeListersReady verifies that
+// the admin-group fallback still works while the RBAC half's listers
+// aren't installed yet — the window WithRBACAuthorizer's doc describes as
+// safe because buildServer always closes it before the server ever serves.
+func TestRBACAuthorizer_FallsBackToAdminGroupBeforeListersReady(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	resolved, err := auth.Resolve(ctx, []auth.Option{
+		auth.WithRBACAuthorizer(auth.RBACAuthorizerConfig{AdminGroups: "platform-admins"}),
+	}, slog.Default())
+	require.NoError(t, err)
+
+	loopbackUser := &user.DefaultInfo{Name: "loopback", Groups: []string{"system:masters"}}
+	attrs := &fakeAttributes{user: loopbackUser, isResource: true, verb: "list", resource: "kontinuums"}
+
+	decision, _, err := resolved.Authorizer.Authorize(ctx, attrs)
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionAllow, decision,
+		"the admin-group fallback must still work while the RBAC listers aren't ready yet")
+}
+
+// TestRBACAuthorizer_GrantsAccessViaRealClusterRoleBinding proves the RBAC
+// half is actually consulted, not just present: a group with no entry in
+// AdminGroups gets access purely because a ClusterRoleBinding/ClusterRole
+// pair grants it, and loses access to anything that pair doesn't cover
+// (the admin-group fallback doesn't recognize the group either).
+func TestRBACAuthorizer_GrantsAccessViaRealClusterRoleBinding(t *testing.T) {
+	t.Parallel()
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "widget-reader"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{"widgets.example.com"}, Resources: []string{"widgets"}, Verbs: []string{"get", "list"}},
+		},
+	}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "widget-readers"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "widget-reader"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "widget-readers"}},
+	}
+
+	roleLister, roleBindingLister, clusterRoleLister, clusterRoleBindingLister :=
+		newSyncedRBACListers(t, clusterRole, clusterRoleBinding)
+
+	ctx := context.Background()
+
+	resolved, err := auth.Resolve(ctx, []auth.Option{
+		auth.WithRBACAuthorizer(auth.RBACAuthorizerConfig{AdminGroups: "platform-admins"}),
+	}, slog.Default())
+	require.NoError(t, err)
+
+	resolved.RBACListerSource.SetListers(roleLister, roleBindingLister, clusterRoleLister, clusterRoleBindingLister)
+
+	reader := &user.DefaultInfo{Name: "bob", Groups: []string{"widget-readers"}}
+
+	allowed := &fakeAttributes{
+		user: reader, isResource: true, verb: "get", apiGroup: "widgets.example.com", resource: "widgets",
+	}
+
+	decision, _, err := resolved.Authorizer.Authorize(ctx, allowed)
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionAllow, decision, "the ClusterRoleBinding's rule should grant this")
+
+	notAllowed := &fakeAttributes{
+		user: reader, isResource: true, verb: "delete", apiGroup: "widgets.example.com", resource: "widgets",
+	}
+
+	decision, _, err = resolved.Authorizer.Authorize(ctx, notAllowed)
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionDeny, decision,
+		"delete isn't in the bound ClusterRole's rules and the user isn't in any admin group, "+
+			"so the admin-group fallback must deny it too")
+}
+

--- a/pkg/libkapi/authoptions.go
+++ b/pkg/libkapi/authoptions.go
@@ -34,6 +34,9 @@ type KeyPersistenceConfig = auth.KeyPersistenceConfig
 // AdminAuthorizerConfig configures the admin authorizer.
 type AdminAuthorizerConfig = auth.AdminAuthorizerConfig
 
+// RBACAuthorizerConfig configures the RBAC authorizer. See WithRBACAuthorizer.
+type RBACAuthorizerConfig = auth.RBACAuthorizerConfig
+
 // ServiceAccountTokenGetter provides access to ServiceAccount, Pod, Secret,
 // and Node objects for token validation.
 type ServiceAccountTokenGetter = auth.ServiceAccountTokenGetter
@@ -73,6 +76,17 @@ func WithAdminAuthorizer(cfg AdminAuthorizerConfig) Option {
 func WithAuthorizer(authz Authorizer) Option {
 	return func(_ context.Context, c *config) error {
 		c.authOpts = append(c.authOpts, auth.WithAuthorizer(authz))
+
+		return nil
+	}
+}
+
+// WithRBACAuthorizer sets an authorizer that evaluates real RBAC rules
+// (Role, RoleBinding, ClusterRole, ClusterRoleBinding), falling back to the
+// same admin-group behavior as WithAdminAuthorizer. See auth.WithRBACAuthorizer.
+func WithRBACAuthorizer(cfg RBACAuthorizerConfig) Option {
+	return func(_ context.Context, c *config) error {
+		c.authOpts = append(c.authOpts, auth.WithRBACAuthorizer(cfg))
 
 		return nil
 	}

--- a/pkg/libkapi/example_test.go
+++ b/pkg/libkapi/example_test.go
@@ -85,11 +85,15 @@ func TestServerEndToEnd(t *testing.T) {
 	assertCRDServerLive(ctx, t, restConfig)
 }
 
-// TestServerEndToEnd_WithAdminAuthorizer verifies that once an authorizer
-// denies anonymous requests, libkapi's own internal loopback client (used by
-// post-start hooks like bootstrap-default-namespace, and by the CRD/
-// APIService informers) still authenticates as a privileged user, while an
-// unauthenticated external caller is denied.
+// assertServerEndToEndDeniesAnonymous builds and starts a real libkapi
+// Server with authOpt as its only authorization option, then verifies
+// libkapi's own internal loopback client (used by post-start hooks like
+// bootstrap-default-namespace, and by the CRD/APIService informers) still
+// authenticates as a privileged user while an unauthenticated external
+// caller is denied — shared by TestServerEndToEnd_WithAdminAuthorizer and
+// TestServerEndToEnd_WithRBACAuthorizer, which differ only in which
+// authorizer option they pass and in what that proves about its own
+// setup (see each test's own doc).
 //
 // Regression test: the loopback client used to carry no bearer token, so it
 // authenticated as system:anonymous exactly like any other caller and was
@@ -99,22 +103,20 @@ func TestServerEndToEnd(t *testing.T) {
 // hook intentionally wants to kill server, let it"), so before the fix this
 // test would crash the whole process instead of ever reaching the assertion
 // below.
-func TestServerEndToEnd_WithAdminAuthorizer(t *testing.T) {
-	t.Parallel()
+func assertServerEndToEndDeniesAnonymous(t *testing.T, dbName string, authOpt libkapi.Option) {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	addr := libkapi.FreeAddr(t)
-	dbPath := filepath.Join(t.TempDir(), "libkapi-admin.db")
+	dbPath := filepath.Join(t.TempDir(), dbName)
 
 	server, err := libkapi.New(ctx,
 		libkapi.WithAddr(addr),
 		libkapi.WithStorage("sqlite://"+dbPath),
 		libkapi.WithLogger(slog.Default()),
-		libkapi.WithAdminAuthorizer(libkapi.AdminAuthorizerConfig{
-			AdminGroups: "test-admins",
-		}),
+		authOpt,
 	)
 	require.NoError(t, err)
 
@@ -139,6 +141,37 @@ func TestServerEndToEnd_WithAdminAuthorizer(t *testing.T) {
 	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
 	require.Error(t, err)
 	assert.True(t, apierrors.IsForbidden(err), "expected anonymous request to be forbidden, got: %v", err)
+}
+
+// TestServerEndToEnd_WithAdminAuthorizer is
+// assertServerEndToEndDeniesAnonymous's regression guard for
+// WithAdminAuthorizer — see that helper's own doc.
+func TestServerEndToEnd_WithAdminAuthorizer(t *testing.T) {
+	t.Parallel()
+
+	assertServerEndToEndDeniesAnonymous(t, "libkapi-admin.db",
+		libkapi.WithAdminAuthorizer(libkapi.AdminAuthorizerConfig{AdminGroups: "test-admins"}))
+}
+
+// TestServerEndToEnd_WithRBACAuthorizer verifies that a real libkapi Server
+// boots and serves correctly with WithRBACAuthorizer configured — in
+// particular, that finishRBACAuthorizer's informer-lister setup (run
+// synchronously during New, before ListenAndServe) doesn't itself break
+// startup — on top of assertServerEndToEndDeniesAnonymous's own regression
+// guard (see its doc).
+//
+// This deliberately doesn't attempt to prove a real ClusterRoleBinding
+// grants access to a non-admin group over live HTTP — doing so here would
+// need a second authenticator (OIDC or ServiceAccount) to mint a token for
+// some identity other than anonymous, adding real complexity for a proof
+// pkg/libkapi/auth/rbac_test.go's
+// TestRBACAuthorizer_GrantsAccessViaRealClusterRoleBinding already gives
+// directly against the resolved authorizer, with no server needed.
+func TestServerEndToEnd_WithRBACAuthorizer(t *testing.T) {
+	t.Parallel()
+
+	assertServerEndToEndDeniesAnonymous(t, "libkapi-rbac.db",
+		libkapi.WithRBACAuthorizer(libkapi.RBACAuthorizerConfig{AdminGroups: "test-admins"}))
 }
 
 func assertCoreV1(ctx context.Context, t *testing.T, kubeClient *kubernetes.Clientset) {

--- a/pkg/libkapi/server.go
+++ b/pkg/libkapi/server.go
@@ -217,6 +217,11 @@ func buildServer(cfg config, addr string, handle *storage.Handle,
 		return nil, fmt.Errorf("failed to set up API server config: %w", err)
 	}
 
+	err = finishRBACAuthorizer(authCfg, genericServerConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	err = resolveAndSetAuth(authCfg, genericServerConfig, controllersLogger)
 	if err != nil {
 		return nil, err
@@ -247,6 +252,58 @@ func buildServer(cfg config, addr string, handle *storage.Handle,
 		postStartHooks:  cfg.postStartHooks,
 		preShutdownHooks: cfg.preShutdownHooks,
 	}, nil
+}
+
+// finishRBACAuthorizer completes WithRBACAuthorizer's setup, if it was used
+// (authCfg.RBACListerSource is nil otherwise, and this is a no-op): it
+// installs rbac/v1 informer listers, built from
+// genericServerConfig.SharedInformerFactory, onto the RBACListerSource the
+// authorizer already holds a reference to (via upstream's RBAC authorizer,
+// itself already wired into authz/genericServerConfig.Authorization.Authorizer/
+// StandardAPIGroups at this point) — see auth.WithRBACAuthorizer's doc for
+// why listers, not a direct client, and why this can't happen any earlier.
+//
+// Accessing SharedInformerFactory.Rbac().V1() registers these four
+// informers on the factory but doesn't start them - nothing populates the
+// listers yet. The post-start hook registered below starts the factory
+// once the server is listening, the same pattern
+// pkg/libkapi/controllers.NewTokenControllerHook uses for its own SA/Secret
+// informers (see token.go's doc: "informers must be registered on the
+// SharedInformerFactory before Start is called"). Calling Start on a
+// factory that's already running (e.g. because WithServiceAccount's own
+// hook already started it) is safe - client-go tracks per-informer state
+// and only starts ones that aren't already running.
+//
+// Called synchronously from buildServer, itself called synchronously from
+// New — entirely before ListenAndServe, so before the listener is ever
+// bound and before any real request could possibly reach the authorizer.
+func finishRBACAuthorizer(authCfg *auth.ResolvedConfig, genericServerConfig *genericapiserver.RecommendedConfig) error {
+	if authCfg.RBACListerSource == nil {
+		return nil
+	}
+
+	rbacInformers := genericServerConfig.SharedInformerFactory.Rbac().V1()
+
+	authCfg.RBACListerSource.SetListers(
+		rbacInformers.Roles().Lister(),
+		rbacInformers.RoleBindings().Lister(),
+		rbacInformers.ClusterRoles().Lister(),
+		rbacInformers.ClusterRoleBindings().Lister(),
+	)
+
+	sharedInformerFactory := genericServerConfig.SharedInformerFactory
+
+	err := genericServerConfig.AddPostStartHook("libkapi-rbac-authorizer-informers",
+		func(ctx genericapiserver.PostStartHookContext) error {
+			sharedInformerFactory.Start(ctx.Done())
+
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("failed to add rbac authorizer informers post-start hook: %w", err)
+	}
+
+	return nil
 }
 
 // newHTTPServer builds the *http.Server for the listener. When grpcServer is


### PR DESCRIPTION
## Summary

- Adds `libkapi.WithRBACAuthorizer(RBACAuthorizerConfig{AdminGroups: ...})`: a new authorizer Option that unions upstream Kubernetes's own RBAC authorizer (evaluating real `Role`/`RoleBinding`/`ClusterRole`/`ClusterRoleBinding` objects) in front of exactly `WithAdminAuthorizer`'s existing deny-by-default behavior.
- Since upstream's RBAC authorizer only ever returns `Allow` or `NoOpinion` for a request — RBAC is purely additive, never a terminal `Deny` — trying it first and falling back to the admin-group authorizer preserves every bit of `WithAdminAuthorizer`'s behavior exactly, while letting real RBAC objects also grant access, so `kubectl auth can-i` reflects reality instead of a grant that only ever existed as an authorizer's in-memory group check.

### The sequencing problem this solves

This came from a downstream consumer (kontinuum) that wanted its own admin-group `ClusterRoleBinding`s to actually be *evaluated*, not just inspectable. Building that entirely from `WithAuthorizer` turned out to need libkapi-internal knowledge of exactly when the server's privileged identity/informers become available — the kind of thing worth solving once, here, rather than in every consumer.

The authorizer needs a client to read `Role`/`RoleBinding`/`ClusterRole`/`ClusterRoleBinding` objects, but that client can't be built until the server's `SharedInformerFactory` exists — which is itself produced by `apiserver.SetupAPIServerConfig`, called *with the resolved authorizer as an argument* (needed for the rbac REST storage provider's own bootstrap-roles wiring). So the authorizer and its own backing client can't both exist before the other. `WithRBACAuthorizer` breaks this by installing an `RBACListerSource` with no listers yet; a new `finishRBACAuthorizer` step in `buildServer` calls `SetListers` on it once the factory is available — synchronously within `New`, entirely before `ListenAndServe` — so there's no window where a real request could reach the authorizer before it's ready.

### The recursion bug this caught

`RBACListerSource` is backed by client-go's **informer listers**, not a direct per-call API request. I tried the direct-client version first, and `TestServerEndToEnd_WithRBACAuthorizer` hung until timeout: a direct client makes `Authorize` itself issue a new HTTP request against *this same server* to decide whether to authorize the very request in progress — to check "can this list `ClusterRoleBindings`," it needs to list `ClusterRoleBindings`, which needs authorizing, which needs to list `ClusterRoleBindings`... Informer listers read a local, continuously-updated cache instead — never blocking, never making a new outbound call from inside `Authorize` — exactly how upstream kube-apiserver's own RBAC authorizer avoids the same trap (it's built from `SharedInformerFactory` listers too, never a live client).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (multiple runs — one transient failure under full-suite parallel load reproduced as a pass on 3 subsequent runs; isolated `pkg/libkapi/...` runs were consistently clean)
- [x] `go tool golangci-lint run ./...` (0 issues)
- [x] New `pkg/libkapi/auth/rbac_test.go`: `RBACListerSource` before/after `SetListers`, admin-group fallback while listers aren't ready, and an end-to-end case proving a hand-built `ClusterRole`/`ClusterRoleBinding` pair actually grants (and correctly denies) access through the real RBAC path
- [x] New `TestServerEndToEnd_WithRBACAuthorizer` in `pkg/libkapi/example_test.go` — a real server, real listener, confirms anonymous requests are still denied and startup doesn't hang/crash (this is exactly the regression the recursion bug above would have caused)
- [x] README updated: new option row, `RBACAuthorizerConfig` field table, a "RBAC authorizer" section explaining the sequencing, and the security-posture/error tables extended

🤖 Generated with [Claude Code](https://claude.com/claude-code)