### PR TITLE
fix(kommodity-cluster): add volumeType field to UserVolumeConfig template

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.4
+version: 0.26.5
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/talos/instance-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/instance-volumes.yaml
@@ -12,9 +12,12 @@ ScalewayMachineTemplate / AzureMachineTemplate.
 Each entry supports:
   - nameSuffix (required): Talos volume name, mounted at /var/mnt/<nameSuffix>
   - diskSelector (required): CEL expression matching the target disk.
-  - grow (optional, default false): grow to fill disk on subsequent boots
-  - minSize (optional): minimum partition size
-  - maxSize (optional): maximum partition size
+  - volumeType (optional, default "partition"): "disk" or "partition"
+      "disk" takes over the entire disk (no grow/minSize/maxSize)
+      "partition" creates a partition (requires minSize or maxSize)
+  - grow (optional, default false): grow to fill disk (partition only)
+  - minSize (optional): minimum partition size (partition only)
+  - maxSize (optional): maximum partition size (partition only)
   - encryption (optional):
       provider: luks2
       keySource: nodeID or kms (default: kms when kommodity.kms.enabled, else nodeID)
@@ -74,20 +77,30 @@ Returns empty string when instanceVolumes is not set or empty.
 {{- $enc := default dict (dig "encryption" nil $vol) -}}
 {{- $encProvider := default "luks2" (dig "provider" "" $enc) -}}
 {{- $keySource := default (ternary "kms" "nodeID" $kmsEnabled) (dig "keySource" "" $enc) -}}
+{{- $volumeType := default "partition" $vol.volumeType -}}
+{{- $validVolumeTypes := list "disk" "partition" "directory" -}}
+{{- if not (has $volumeType $validVolumeTypes) -}}
+{{- fail (printf "instanceVolumes[].volumeType must be one of %s, got %q" (join ", " $validVolumeTypes) $volumeType) -}}
+{{- end -}}
 - |
   apiVersion: v1alpha1
   kind: UserVolumeConfig
   name: {{ $name }}
+  volumeType: {{ $volumeType | quote }}
   provisioning:
     diskSelector:
       match: {{ $selector | quote }}
+{{- if ne $volumeType "disk" }}
 {{- with $vol.minSize }}
     minSize: {{ . }}
 {{- end }}
 {{- with $vol.maxSize }}
     maxSize: {{ . }}
 {{- end }}
-    grow: {{ $vol.grow | default false }}
+{{- if (dig "grow" false $vol) }}
+    grow: true
+{{- end }}
+{{- end }}
 {{- if $enc }}
   encryption:
     provider: {{ $encProvider }}

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -316,6 +316,7 @@ tests:
       kommodity.nodepools.default.instanceVolumes:
         - nameSuffix: scratch
           diskSelector: "disk.model == 'scratch'"
+          volumeType: partition
           grow: true
     asserts:
       - matchRegex:
@@ -326,10 +327,51 @@ tests:
           pattern: "name: scratch"
       - matchRegex:
           path: spec.template.spec.strategicPatches[1]
+          pattern: 'volumeType: "partition"'
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
           pattern: "grow: true"
       - matchRegex:
           path: spec.template.spec.strategicPatches[1]
           pattern: "disk.model == 'scratch'"
+
+  - it: should default volumeType to partition when omitted
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.model == 'scratch'"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: 'volumeType: "partition"'
+
+  - it: should suppress grow, minSize, maxSize for volumeType disk
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.instanceVolumes:
+        - nameSuffix: scratch
+          diskSelector: "disk.dev_path == '/dev/sdb'"
+          volumeType: disk
+          grow: true
+          minSize: 100GiB
+          maxSize: 200GiB
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: 'volumeType: "disk"'
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "grow:"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "minSize:"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "maxSize:"
 
   - it: should emit UserVolumeConfig for controlplane instanceVolumes
     template: templates/talos/controlplane.yaml


### PR DESCRIPTION
## Summary

Fix the `instanceVolumes` template to include the `volumeType` field required by Talos 1.13's `UserVolumeConfig`.

Without `volumeType`, nodes hang during boot and never join the cluster — Talos rejects the machine config silently. Additionally, `grow` is not supported for `volumeType: disk`, so the template now conditionally renders it only for non-disk volume types.

## Changes

- Add `volumeType` field to UserVolumeConfig (defaults to `partition`)
- Only render `grow` for non-disk volume types (Talos rejects `grow` on `volumeType: disk`)
- Update template documentation for `volumeType`, `grow`, `minSize`, `maxSize`
- Bump chart version 0.26.4 → 0.26.5

## Verification

Verified on live dev-par02 cluster with `wachs-experimental` nodepool:
- Node with `volumeType: disk` + luks2/KMS encryption joins cluster successfully
- `/dev/sdb` (3.0 TB scratch) → luks2 encrypted → `/dev/dm-2` (xfs) → mounted at `/var/mnt/scratch`
- KMS endpoint `https://kommodity.dev.corti.app` working
- `lockToState: true` working
- Config validated with `talosctl validate --mode metal`
