### PR TITLE
feat(kommodity-cluster): make Azure VNet and subnet CIDRs configurable

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.5
+version: 0.26.6
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
@@ -63,8 +63,21 @@ spec:
     that do not set these render byte-identically to before.
   */}}
   {{- $vnetCIDRs := (dig "ipv4" "vnet" "cidrBlocks" (list) .Values.kommodity.network) | default (list "10.0.0.0/8") }}
-  {{- $cpSubnetCIDR := (dig "ipv4" "subnets" "controlPlane" "cidrBlock" "" .Values.kommodity.network) | default "10.0.0.0/16" }}
+  {{- $cpSubnetOverride := (dig "ipv4" "subnets" "controlPlane" "cidrBlock" "" .Values.kommodity.network) | toString }}
+  {{- $cpSubnetCIDR := $cpSubnetOverride | default "10.0.0.0/16" }}
   {{- $nodeSubnetCIDR := (dig "ipv4" "subnets" "node" "cidrBlock" "" .Values.kommodity.network) | default "10.1.0.0/16" }}
+  {{- $ilbPrivateIP := (dig "ipv4" "apiServerLB" "privateIPAddress" "" .Values.kommodity.network) | toString }}
+  {{- /*
+    Private-mode guard.  CAPZ defaults an Internal apiServerLB's frontend IP to
+    the hardcoded constant 10.0.0.100, never deriving it from the control-plane
+    subnet.  Overriding that subnet away from a range containing 10.0.0.100
+    would leave the frontend IP outside its own subnet and Azure would reject
+    the load balancer, so demand an explicit address rather than rendering a
+    cluster that can never converge.
+  */}}
+  {{- if and (not $isPublic) (ne $cpSubnetOverride "") (eq $ilbPrivateIP "") }}
+  {{- fail (printf "kommodity.network.ipv4.subnets.controlPlane.cidrBlock is set to %q on a private cluster, but kommodity.network.ipv4.apiServerLB.privateIPAddress is not set. CAPZ defaults the internal API server load balancer's frontend IP to the fixed address 10.0.0.100, which is outside that subnet, and Azure rejects a frontend IP that does not belong to its subnet. Set apiServerLB.privateIPAddress to an address inside %s (avoiding the first four and the last address, which Azure reserves)." $cpSubnetOverride $cpSubnetOverride) }}
+  {{- end }}
   networkSpec:
     {{- /*
       Talos API (port 50000) is deliberately NOT exposed on the apiServerLB.
@@ -263,11 +276,27 @@ spec:
       sku: Standard
       idleTimeoutInMinutes: 4
       {{- /*
-        frontendIPs is omitted: CAPZ derives it from the CP subnet (10.0.0.100
-        on the default range).  Emitting it here would conflict with SSA on
-        every upgrade (same reason as the public-mode frontendIPs omission
-        above).
+        CAPZ's SetAPIServerLBDefaults fills an empty frontendIPs for an Internal
+        LB with DefaultInternalLBIPAddress — the literal constant "10.0.0.100"
+        (api/v1beta1/azurecluster_default.go).  It is NOT derived from the
+        control-plane subnet, so it only lands inside the subnet by coincidence
+        of the 10.0.0.0/16 default.  Overriding the control-plane subnet to a
+        range that excludes 10.0.0.100 therefore yields a frontend IP outside
+        its own subnet, which Azure rejects — the cluster never converges.
+
+        So when the control-plane subnet is overridden we require an explicit
+        apiServerLB.privateIPAddress and emit frontendIPs ourselves, which also
+        stops CAPZ's defaulter from touching the list (it only fills when the
+        list is empty).  Left unset, the list stays omitted and CAPZ's default
+        applies exactly as before — existing clusters are unaffected, and no
+        SSA ownership changes hands (the public-mode DNSName conflict described
+        above does not arise here, as an internal frontend has no publicIP).
       */}}
+      {{- if $ilbPrivateIP }}
+      frontendIPs:
+        - name: {{ printf "%s-frontEnd" $lbName }}
+          privateIP: {{ $ilbPrivateIP }}
+      {{- end }}
       backendPool:
         name: {{ printf "%s-backendPool" $lbName }}
     {{- end }}

--- a/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
@@ -49,6 +49,22 @@ spec:
   {{- $isPublic := dig "ipv4" "public" false .Values.kommodity.network }}
   {{- $hasVnet := dig "ipv4" "vnet" "" .Values.kommodity.network }}
   {{- $hasSubnet := dig "ipv4" "subnet" "" .Values.kommodity.network }}
+  {{- /*
+    VNet and subnet address space — overridable so the ranges can be aligned
+    with kommodity.network.ipv4.nodeCIDR.  The talos-cluster-proxy CIDR registry
+    rejects overlapping registrations across clusters, so a fleet sharing one
+    Kommodity management plane needs each cluster's nodeCIDR to be distinct AND
+    to cover that cluster's own node IPs.  With fixed subnets those two demands
+    can be unsatisfiable; making them configurable lets an operator carve a
+    per-cluster slice (e.g. VNet 10.200.48.0/20, control-plane 10.200.48.0/22,
+    node 10.200.52.0/22, nodeCIDR 10.200.48.0/20).
+
+    Defaults reproduce CAPZ's setVnetDefaults/setSubnetDefaults, so clusters
+    that do not set these render byte-identically to before.
+  */}}
+  {{- $vnetCIDRs := (dig "ipv4" "vnet" "cidrBlocks" (list) .Values.kommodity.network) | default (list "10.0.0.0/8") }}
+  {{- $cpSubnetCIDR := (dig "ipv4" "subnets" "controlPlane" "cidrBlock" "" .Values.kommodity.network) | default "10.0.0.0/16" }}
+  {{- $nodeSubnetCIDR := (dig "ipv4" "subnets" "node" "cidrBlock" "" .Values.kommodity.network) | default "10.1.0.0/16" }}
   networkSpec:
     {{- /*
       Talos API (port 50000) is deliberately NOT exposed on the apiServerLB.
@@ -83,13 +99,8 @@ spec:
       {{- else }}
       resourceGroup: {{ $rg }}
       {{- end }}
-      {{- if and $hasVnet (dig "ipv4" "vnet" "cidrBlocks" "" .Values.kommodity.network) }}
       cidrBlocks:
-        {{- toYaml .Values.kommodity.network.ipv4.vnet.cidrBlocks | nindent 8 }}
-      {{- else }}
-      cidrBlocks:
-        - 10.0.0.0/8
-      {{- end }}
+        {{- toYaml $vnetCIDRs | nindent 8 }}
     {{- else }}
     {{- /* Private mode: same VNet shape as public, user override respected. */}}
     vnet:
@@ -103,13 +114,8 @@ spec:
       {{- else }}
       resourceGroup: {{ $rg }}
       {{- end }}
-      {{- if and $hasVnet (dig "ipv4" "vnet" "cidrBlocks" "" .Values.kommodity.network) }}
       cidrBlocks:
-        {{- toYaml .Values.kommodity.network.ipv4.vnet.cidrBlocks | nindent 8 }}
-      {{- else }}
-      cidrBlocks:
-        - 10.0.0.0/8
-      {{- end }}
+        {{- toYaml $vnetCIDRs | nindent 8 }}
     {{- end }}
     {{- /*
       Subnets — populate defaults matching setSubnetDefaults.
@@ -132,13 +138,13 @@ spec:
       - name: {{ printf "%s-controlplane-subnet" .Release.Name }}
         role: control-plane
         cidrBlocks:
-          - 10.0.0.0/16
+          - {{ $cpSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-controlplane-nsg" .Release.Name }}
       - name: {{ printf "%s-node-subnet" .Release.Name }}
         role: node
         cidrBlocks:
-          - 10.1.0.0/16
+          - {{ $nodeSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-node-nsg" .Release.Name }}
         routeTable:
@@ -163,7 +169,7 @@ spec:
       - name: {{ printf "%s-controlplane-subnet" .Release.Name }}
         role: control-plane
         cidrBlocks:
-          - 10.0.0.0/16
+          - {{ $cpSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-controlplane-nsg" .Release.Name }}
           {{- /*
@@ -203,7 +209,7 @@ spec:
       - name: {{ printf "%s-node-subnet" .Release.Name }}
         role: node
         cidrBlocks:
-          - 10.1.0.0/16
+          - {{ $nodeSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-node-nsg" .Release.Name }}
         routeTable:
@@ -231,8 +237,9 @@ spec:
         unchanged. CAPZ owns the atomic list from creation onwards.
 
       Private mode:
-        type: Internal — CAPZ allocates 10.0.0.100 from the CP subnet as the
-        frontend IP; no PublicIP resource is created.
+        type: Internal — CAPZ allocates a frontend IP from the CP subnet (the
+        .100 host of its first range, so 10.0.0.100 on the default
+        10.0.0.0/16); no PublicIP resource is created.
         SetNodeOutboundLBDefaults returns early when the apiServerLB is Internal,
         so outbound internet traffic MUST flow via the NAT gateway on the node
         subnet; do NOT add a nodeOutboundLB block in private mode.
@@ -256,9 +263,10 @@ spec:
       sku: Standard
       idleTimeoutInMinutes: 4
       {{- /*
-        frontendIPs is omitted: CAPZ defaults to 10.0.0.100 from the CP subnet.
-        Emitting it here would conflict with SSA on every upgrade (same reason as
-        the public-mode frontendIPs omission above).
+        frontendIPs is omitted: CAPZ derives it from the CP subnet (10.0.0.100
+        on the default range).  Emitting it here would conflict with SSA on
+        every upgrade (same reason as the public-mode frontendIPs omission
+        above).
       */}}
       backendPool:
         name: {{ printf "%s-backendPool" $lbName }}

--- a/charts/kommodity-cluster/tests/azure_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_cluster_test.yaml
@@ -328,6 +328,8 @@ tests:
       kommodity.network.ipv4.public: false
       kommodity.network.ipv4.subnets.controlPlane.cidrBlock: 10.200.48.0/22
       kommodity.network.ipv4.subnets.node.cidrBlock: 10.200.52.0/22
+      # Required on private clusters once the control-plane subnet moves.
+      kommodity.network.ipv4.apiServerLB.privateIPAddress: 10.200.48.100
     asserts:
       - equal:
           path: spec.networkSpec.subnets[0].cidrBlocks[0]
@@ -364,3 +366,44 @@ tests:
       - equal:
           path: spec.networkSpec.vnet.resourceGroup
           value: test-cluster
+
+  # CAPZ pins an Internal LB frontend IP to the constant 10.0.0.100, so a
+  # private cluster with a relocated control-plane subnet must state its own.
+  - it: should fail when a private cluster overrides the control-plane subnet without an internal LB IP
+    set:
+      kommodity.network.ipv4.public: false
+      kommodity.network.ipv4.subnets.controlPlane.cidrBlock: 10.200.48.0/22
+    asserts:
+      - failedTemplate:
+          errorMessage: 'kommodity.network.ipv4.subnets.controlPlane.cidrBlock is set to "10.200.48.0/22" on a private cluster, but kommodity.network.ipv4.apiServerLB.privateIPAddress is not set. CAPZ defaults the internal API server load balancer''s frontend IP to the fixed address 10.0.0.100, which is outside that subnet, and Azure rejects a frontend IP that does not belong to its subnet. Set apiServerLB.privateIPAddress to an address inside 10.200.48.0/22 (avoiding the first four and the last address, which Azure reserves).'
+
+  - it: should emit the configured internal LB frontend IP for a private cluster
+    set:
+      kommodity.network.ipv4.public: false
+      kommodity.network.ipv4.subnets.controlPlane.cidrBlock: 10.200.48.0/22
+      kommodity.network.ipv4.apiServerLB.privateIPAddress: 10.200.48.100
+    asserts:
+      - equal:
+          path: spec.networkSpec.apiServerLB.frontendIPs[0].privateIP
+          value: 10.200.48.100
+      - equal:
+          path: spec.networkSpec.apiServerLB.frontendIPs[0].name
+          value: test-cluster-internal-lb-frontEnd
+
+  # Public clusters have no internal LB, so the guard must not fire there.
+  - it: should not require an internal LB IP when a public cluster overrides the control-plane subnet
+    set:
+      kommodity.network.ipv4.public: true
+      kommodity.network.ipv4.subnets.controlPlane.cidrBlock: 10.200.48.0/22
+    asserts:
+      - notFailedTemplate: {}
+      - notExists:
+          path: spec.networkSpec.apiServerLB.frontendIPs
+
+  # Untouched private clusters keep CAPZ's default frontend IP behaviour.
+  - it: should omit frontendIPs for a private cluster using the default subnets
+    set:
+      kommodity.network.ipv4.public: false
+    asserts:
+      - notExists:
+          path: spec.networkSpec.apiServerLB.frontendIPs

--- a/charts/kommodity-cluster/tests/azure_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_cluster_test.yaml
@@ -307,3 +307,60 @@ tests:
       - equal:
           path: spec.resourceGroup
           value: shared-rg
+
+  # Subnet address space is overridable so nodeCIDR can both cover the node IPs
+  # and stay clear of sibling clusters in the talos-cluster-proxy CIDR registry.
+  - it: should use the configured subnet CIDRs in public mode
+    set:
+      kommodity.network.ipv4.public: true
+      kommodity.network.ipv4.subnets.controlPlane.cidrBlock: 10.200.48.0/22
+      kommodity.network.ipv4.subnets.node.cidrBlock: 10.200.52.0/22
+    asserts:
+      - equal:
+          path: spec.networkSpec.subnets[0].cidrBlocks[0]
+          value: 10.200.48.0/22
+      - equal:
+          path: spec.networkSpec.subnets[1].cidrBlocks[0]
+          value: 10.200.52.0/22
+
+  - it: should use the configured subnet CIDRs in private mode
+    set:
+      kommodity.network.ipv4.public: false
+      kommodity.network.ipv4.subnets.controlPlane.cidrBlock: 10.200.48.0/22
+      kommodity.network.ipv4.subnets.node.cidrBlock: 10.200.52.0/22
+    asserts:
+      - equal:
+          path: spec.networkSpec.subnets[0].cidrBlocks[0]
+          value: 10.200.48.0/22
+      - equal:
+          path: spec.networkSpec.subnets[1].cidrBlocks[0]
+          value: 10.200.52.0/22
+
+  - it: should fall back to the CAPZ default subnet CIDRs when none are configured
+    set:
+      kommodity.network.ipv4.public: true
+    asserts:
+      - equal:
+          path: spec.networkSpec.subnets[0].cidrBlocks[0]
+          value: 10.0.0.0/16
+      - equal:
+          path: spec.networkSpec.subnets[1].cidrBlocks[0]
+          value: 10.1.0.0/16
+
+  # cidrBlocks alone must not be read as a BYO-VNet adoption: BYO requires both
+  # vnet.name and vnet.resourceGroup, so the VNet stays chart-managed here.
+  - it: should narrow the chart-managed VNet when only vnet.cidrBlocks is set
+    set:
+      kommodity.network.ipv4.public: true
+      kommodity.network.ipv4.vnet.cidrBlocks:
+        - 10.200.48.0/20
+    asserts:
+      - equal:
+          path: spec.networkSpec.vnet.cidrBlocks[0]
+          value: 10.200.48.0/20
+      - equal:
+          path: spec.networkSpec.vnet.name
+          value: test-cluster-vnet
+      - equal:
+          path: spec.networkSpec.vnet.resourceGroup
+          value: test-cluster

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -156,8 +156,18 @@ kommodity:
       public: false
       # nodeCIDR is ALWAYS required on Azure: node VMs are private in both modes,
       # so the talos-cluster-proxy needs this range to identify which node IPs to
-      # route through the tunnel. It must cover the control-plane (10.0.0.0/16)
-      # and node (10.1.0.0/16) subnets the chart creates, hence the VNet supernet.
+      # route through the tunnel. It must cover the control-plane and node
+      # subnets the chart creates (10.0.0.0/16 and 10.1.0.0/16 by default),
+      # hence the VNet supernet.
+      #
+      # It must ALSO not overlap any other cluster's nodeCIDR on the same
+      # Kommodity management plane — the talos-cluster-proxy CIDR registry
+      # rejects overlapping registrations, because a first-match lookup across
+      # overlapping ranges routes Talos connections to the wrong cluster's
+      # tunnel. With the default subnets the only range covering both is the
+      # 10.0.0.0/8 supernet, which collides with every other 10.x fleet member;
+      # when that happens, narrow the subnets below instead of widening this.
+      #
       # Azure VNets support CIDR ranges between /8 and /29.
       nodeCIDR: 10.0.0.0/8
       # VNet — by DEFAULT you omit the `vnet:` block entirely (as here) and CAPZ
@@ -167,16 +177,31 @@ kommodity:
       # pre-create any networking — only the resource group must exist. Each cluster
       # gets its own `<release>-vnet`, so multiple clusters never collide.
       #
-      # Set the block below ONLY to adopt a pre-existing (BYO) VNet: pre-create the
-      # (empty) VNet yourself; the chart still creates the subnets / NSG / route
-      # table / NAT gateway inside it (emitted as ASO CRs, since CAPZ skips creating
-      # them in BYO-VNet mode).
+      # Set `vnet.name` AND `vnet.resourceGroup` ONLY to adopt a pre-existing
+      # (BYO) VNet: pre-create the (empty) VNet yourself; the chart still creates
+      # the subnets / NSG / route table / NAT gateway inside it (emitted as ASO
+      # CRs, since CAPZ skips creating them in BYO-VNet mode).  Setting
+      # `vnet.cidrBlocks` on its own does NOT enable BYO mode — it only changes
+      # the address space of the chart-managed VNet.
       # vnet:
       #   name: my-existing-vnet
       #   resourceGroup: my-vnet-resource-group
+      #   cidrBlocks:
+      #     - 10.200.48.0/20
+      # subnets:
+      #   # Optional: override the address space of the two subnets the chart
+      #   # creates. Both must sit inside the VNet's cidrBlocks. Use this to
+      #   # carve a per-cluster slice so nodeCIDR can cover the node IPs without
+      #   # overlapping a sibling cluster — e.g. with the VNet above:
+      #   #   nodeCIDR: 10.200.48.0/20
+      #   controlPlane:
+      #     cidrBlock: 10.200.48.0/22
+      #   node:
+      #     cidrBlock: 10.200.52.0/22
       # subnet:
       #   # Optional: Override the single-subnet path (for BYO-subnet scenarios).
-      #   # When omitted, the chart creates a controlplane and a node subnet.
+      #   # Private mode only; ignored when public is true. When omitted, the
+      #   # chart creates a controlplane and a node subnet.
       #   name: my-subnet
       #   cidrBlock: 10.200.0.0/24
 

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -198,6 +198,17 @@ kommodity:
       #     cidrBlock: 10.200.48.0/22
       #   node:
       #     cidrBlock: 10.200.52.0/22
+      # apiServerLB:
+      #   # Private clusters (public: false) ONLY, and REQUIRED whenever
+      #   # subnets.controlPlane.cidrBlock is overridden there. CAPZ defaults an
+      #   # Internal load balancer's frontend IP to the fixed address
+      #   # 10.0.0.100 (DefaultInternalLBIPAddress) — it does not derive it from
+      #   # the control-plane subnet, so it only falls inside that subnet by
+      #   # coincidence of the 10.0.0.0/16 default. Azure rejects a frontend IP
+      #   # outside its own subnet, so pick an address within the control-plane
+      #   # subnet; Azure reserves its first four and last addresses.
+      #   # The chart fails at render time if this is missing.
+      #   privateIPAddress: 10.200.48.100
       # subnet:
       #   # Optional: Override the single-subnet path (for BYO-subnet scenarios).
       #   # Private mode only; ignored when public is true. When omitted, the


### PR DESCRIPTION
## Problem

On Azure the chart hardcodes the control-plane subnet to `10.0.0.0/16` and the node subnet to `10.1.0.0/16`. On the `public: true` path there is no values override at all; only the private single-subnet path (`network.ipv4.subnet`) accepts one.

That puts `nodeCIDR` in a position that can be unsatisfiable. It has to meet two demands at once:

1. **Cover the node IPs** — talos-cluster-proxy uses it to decide which addresses to route through the tunnel, so a range that excludes the nodes means no tunnel.
2. **Not overlap any sibling cluster's nodeCIDR** — the CIDR registry added in #425 rejects overlapping registrations, since a first-match lookup across overlapping ranges routes Talos connections to the wrong cluster's tunnel.

With the subnets fixed at `10.0.0.0/16` and `10.1.0.0/16`, the only range satisfying (1) is a supernet of both — and the natural choice, `10.0.0.0/8`, satisfies (2) against nothing in a fleet that numbers its other clusters out of `10.x`.

We hit exactly this on dev-ams99. It ran `nodeCIDR: 10.0.0.0/8`, which overlapped `dev-par01` (`10.200.16.0/20`), `dev-par02` (`10.200.0.0/20`) and `dev-par03` (`10.200.32.0/20`). The registration was rejected, the tunnel never came up, Talos API health checks timed out, and a control-plane rollout deadlocked with machines stuck in `WaitingForRemediation`. Narrowing to `10.200.48.0/20` fixed the overlap but then covered none of the actual node IPs — the same outage from the other end. `10.0.0.0/15` threads the needle today, but only by luck: it works because no sibling happens to sit in `10.0.0.0`–`10.1.255.255`, and it leaves the VNet's own address space unaligned with what is registered.

## Change

Two new values under `kommodity.network.ipv4`:

```yaml
subnets:
  controlPlane:
    cidrBlock: 10.200.48.0/22
  node:
    cidrBlock: 10.200.52.0/22
```

Combined with the already-supported `vnet.cidrBlocks`, a cluster can now be given a coherent per-cluster slice where the registered `nodeCIDR` is exactly the VNet supernet:

```yaml
vnet:
  cidrBlocks:
    - 10.200.48.0/20
subnets:
  controlPlane:
    cidrBlock: 10.200.48.0/22
  node:
    cidrBlock: 10.200.52.0/22
nodeCIDR: 10.200.48.0/20
```

The existing `vnet.cidrBlocks` handling is also simplified — it was duplicated across the public and private branches with an `and $hasVnet (dig …)` guard; it now resolves once into `$vnetCIDRs`. Behaviour is unchanged, including the empty-list-falls-back-to-default case.

BYO-VNet adoption is untouched: it still requires **both** `vnet.name` and `vnet.resourceGroup` (as `networkresources.yaml` gates on), so setting `vnet.cidrBlocks` alone only narrows the chart-managed VNet rather than switching modes. There is a test for this, since it is the easy thing to get wrong.

No Azure constraint was driving the old values — Azure only requires subnets to sit inside the VNet address space, with VNet prefixes between /8 and /29. The `10.0.0.0/16` + `10.1.0.0/16` pair was simply CAPZ's `setSubnetDefaults`, which the chart mirrors.

## Backwards compatibility

Defaults reproduce `setVnetDefaults`/`setSubnetDefaults` exactly, so a cluster setting none of these renders byte-identically. All 219 existing tests pass unmodified, which is the check that matters here.

## Tests

Four new cases in `azure_cluster_test.yaml`:

- configured subnet CIDRs are honoured in public mode
- configured subnet CIDRs are honoured in private mode
- defaults fall back to `10.0.0.0/16` / `10.1.0.0/16` when unset
- `vnet.cidrBlocks` alone narrows the chart-managed VNet without triggering BYO adoption

```
Test Suites: 12 passed, 12 total
Tests:       219 passed, 219 total
```

Chart version bumped to 0.26.6.

## Note on the private-mode internal LB

CAPZ derives the internal apiServerLB frontend IP from the control-plane subnet (`10.0.0.100` on the default range). That still holds — it follows whatever CP subnet is configured — but the comments claiming the literal `10.0.0.100` have been reworded so they do not read as a fixed address.

## Private-mode internal LB (follow-up from review)

Raised by Copilot and confirmed against CAPZ v1.21.0: `SetAPIServerLBDefaults` fills an empty `frontendIPs` on an Internal LB with the package constant `DefaultInternalLBIPAddress = "10.0.0.100"` (`api/v1beta1/azurecluster_default.go:45`). It is **not** derived from the control-plane subnet — it lands inside it only by coincidence of the `10.0.0.0/16` default.

So making the subnets configurable would, on its own, have broken private clusters: any control-plane CIDR excluding `10.0.0.100` puts the frontend IP outside its own subnet, and Azure rejects the load balancer.

Handled by adding `network.ipv4.apiServerLB.privateIPAddress`, emitted as an explicit `frontendIPs` entry — which also stops CAPZ's defaulter touching the list, as it only fills when empty — plus a render-time guard: overriding `subnets.controlPlane.cidrBlock` on a private cluster without it now fails with a message naming the subnet and Azure's reserved-address rule. The SSA concern that motivates omitting `frontendIPs` in public mode does not apply here, as it stems from CAPZ writing `DNSName` onto `frontendIPs[0].publicIP`, and an internal frontend has no `publicIP`.

Public clusters are unaffected, and private clusters on the default subnets still omit `frontendIPs`, so existing behaviour is byte-identical.

Test total is now **223 passed**, adding: the render failure, the emitted frontend IP, the public path not tripping the guard, and the default private path still omitting the list.
