### PR TITLE
feat(kommodity-cluster): support acceleratedNetworking for Azure machine pools

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.5
+version: 0.26.6
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -208,6 +208,9 @@ Any values that should trigger a new Machine template when changed should be add
 {{- end -}}
 {{- $_ := set $data "diskSize" (dig "os" "disk" "size" "" .poolValues) -}}
 {{- $_ := set $data "gpus" (dig "gpus" "" .poolValues) -}}
+{{- if and (eq .allValues.kommodity.provider.name "Azure") (hasKey .poolValues "acceleratedNetworking") -}}
+{{- $_ := set $data "acceleratedNetworking" .poolValues.acceleratedNetworking -}}
+{{- end -}}
 {{- with (dig "additionalVolumes" "" .poolValues) -}}
 	{{- $_ := set $data "additionalVolumes" . -}}
 {{- end -}}

--- a/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/machinetemplate.yaml
@@ -25,6 +25,10 @@ spec:
         osType: Linux
         managedDisk:
           storageAccountType: {{ default "Premium_LRS" .Values.kommodity.controlplane.os.disk.type }}
+      {{- if hasKey .Values.kommodity.controlplane "acceleratedNetworking" }}
+      networkInterfaces:
+        - acceleratedNetworking: {{ .Values.kommodity.controlplane.acceleratedNetworking }}
+      {{- end }}
       {{- if .Values.kommodity.controlplane.additionalVolumes }}
       dataDisks:
         {{- range .Values.kommodity.controlplane.additionalVolumes }}
@@ -63,6 +67,10 @@ spec:
         osType: Linux
         managedDisk:
           storageAccountType: {{ default "Premium_LRS" $np.os.disk.type }}
+      {{- if hasKey $np "acceleratedNetworking" }}
+      networkInterfaces:
+        - acceleratedNetworking: {{ $np.acceleratedNetworking }}
+      {{- end }}
       {{- if $np.additionalVolumes }}
       dataDisks:
         {{- range $np.additionalVolumes }}

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -283,6 +283,56 @@ tests:
           path: spec.template.spec.dataDisks
         documentIndex: 1
 
+  - it: should omit networkInterfaces when acceleratedNetworking is not set
+    template: templates/provider/azure/machinetemplate.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.networkInterfaces
+        documentIndex: 0
+      - notExists:
+          path: spec.template.spec.networkInterfaces
+        documentIndex: 1
+
+  - it: should set acceleratedNetworking on controlplane and nodepool when configured
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      kommodity.controlplane.acceleratedNetworking: false
+      kommodity.nodepools.default.acceleratedNetworking: false
+    asserts:
+      - equal:
+          path: spec.template.spec.networkInterfaces[0].acceleratedNetworking
+          value: false
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.networkInterfaces[0].acceleratedNetworking
+          value: false
+        documentIndex: 1
+
+  - it: should render acceleratedNetworking true when explicitly enabled
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      kommodity.controlplane.acceleratedNetworking: true
+      kommodity.nodepools.default.acceleratedNetworking: true
+    asserts:
+      - equal:
+          path: spec.template.spec.networkInterfaces[0].acceleratedNetworking
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.networkInterfaces[0].acceleratedNetworking
+          value: true
+        documentIndex: 1
+
+  - it: should mint a new AzureMachineTemplate when acceleratedNetworking is set
+    template: templates/provider/azure/machinetemplate.yaml
+    set:
+      kommodity.nodepools.default.acceleratedNetworking: false
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-cluster-worker-default-[a-f0-9]{6}$
+        documentIndex: 1
+
   - it: should mint a new AzureMachineTemplate when additionalVolumes change
     template: templates/provider/azure/machinetemplate.yaml
     set:

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -187,6 +187,11 @@ kommodity:
     # Optional failure domains.
     # zones:
     #   - "1"
+    # Explicitly enable/disable Azure Accelerated Networking (SR-IOV) on the
+    # control plane node NICs. When omitted, CAPZ derives it from the VM size, and
+    # Azure may non-deterministically attach SR-IOV virtual functions (mlx5_core)
+    # that Talos cannot manage, causing NIC flapping.
+    # acceleratedNetworking: false
     os:
       disk:
         size: 30
@@ -215,6 +220,9 @@ kommodity:
       # Optional failure domains.
       # zones:
       #   - "1"
+      # Explicitly enable/disable Azure Accelerated Networking (SR-IOV) on this
+      # nodepool's NICs (see controlplane above for rationale).
+      # acceleratedNetworking: false
       os:
         disk:
           size: 30


### PR DESCRIPTION
Adds an optional per-pool `acceleratedNetworking` flag (controlplane and nodepools) that renders CAPZ `networkInterfaces[].acceleratedNetworking` on the `AzureMachineTemplate`.

**Problem:** when omitted, CAPZ derives the setting from the VM size, and Azure may non-deterministically attach SR-IOV virtual functions (`mlx5_core`) to hosts. Talos cannot manage VF links (`LinkSpecController: enslaving/unslaving link: operation not supported`), causing NIC flapping that can prevent DHCP, KMS unseal, and node bootstrap entirely.

Setting the flag to `false` disables Accelerated Networking deterministically. Omitting it preserves current behavior — no `networkInterfaces` rendered, no churn on existing clusters.

- Flag is included in `machineSpecsHash`, so changing it mints a new (immutable) `AzureMachineTemplate` and triggers a rolling node replacement.
- Bumps chart version to 0.26.6.
- Adds helm-unittest coverage for absent/enabled/disabled/hash-change cases.
