### PR TITLE
fix(terraform): remove Microsoft.App/environments delegation from container subnet

### DIFF
--- a/terraform/modules/kommodity_azure_deployment/main.tf
+++ b/terraform/modules/kommodity_azure_deployment/main.tf
@@ -153,14 +153,6 @@ resource "azurerm_subnet" "kommodity-container-sn" {
   virtual_network_name = azurerm_virtual_network.kommodity-vn.name
   address_prefixes     = ["${var.virtual_network.container_subnet_prefix}"]
 
-  delegation {
-    name = "Microsoft.App.environments"
-    service_delegation {
-      name    = "Microsoft.App/environments"
-      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-    }
-  }
-
   depends_on = [
     azurerm_resource_group.kommodity-resource-group,
     azurerm_virtual_network.kommodity-vn,


### PR DESCRIPTION
Azure no longer allows subnet delegations on consumption-only Container Apps environments. Any update to `kommodity-*-environment` fails with:

```
ManagedEnvironmentV1SubnetDelegationNotAllowed: The subnet for consumption-only environment must not have delegations. Please remove the delegation 'Microsoft.App/environments' from the subnet and retry the environment creation.
```

Seen in deployments run https://github.com/corticph/deployments/actions/runs/31490850199 (dev, will hit staging/prod too).

Removes the `delegation` block from `azurerm_subnet.kommodity-container-sn`. Terraform applies the subnet change before the environment update (environment already `depends_on` the subnet), so the update then succeeds.