### PR TITLE
fix(terraform): restore subnet delegation for new-generation Container Apps environments

### DIFF
--- a/terraform/modules/kommodity_azure_deployment/main.tf
+++ b/terraform/modules/kommodity_azure_deployment/main.tf
@@ -153,6 +153,14 @@ resource "azurerm_subnet" "kommodity-container-sn" {
   virtual_network_name = azurerm_virtual_network.kommodity-vn.name
   address_prefixes     = ["${var.virtual_network.container_subnet_prefix}"]
 
+  delegation {
+    name = "Microsoft.App.environments"
+    service_delegation {
+      name    = "Microsoft.App/environments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+
   depends_on = [
     azurerm_resource_group.kommodity-resource-group,
     azurerm_virtual_network.kommodity-vn,


### PR DESCRIPTION
## Problem

#439 removed the `Microsoft.App/environments` delegation from the container subnet to unblock updates of **legacy V1 consumption environments** (`ManagedEnvironmentV1SubnetDelegationNotAllowed`).

That blocked **new environment creation** in any environment whose legacy managed environment was removed: Azure requires the delegation on create:

```
ManagedEnvironmentSubnetDelegationError: The subnet of the environment
must be delegated to the service 'Microsoft.App/environments'.
```

Seen in https://github.com/corticph/deployments/actions/runs/31585342811 after the legacy `kommodity-sbx` environment was deleted and Terraform attempted to recreate it.

## Solution

Restore the delegation block on `azurerm_subnet.kommodity-container-sn`. Legacy environments that rejected delegated subnets no longer exist; new-generation environments require it.

## Verification

- [ ] `infrastructure/dev/kommodity-sbx` apply recreates `kommodity-sbx-environment` and `kommodity-sbx-app`
- [ ] `infrastructure/dev/kommodity-dev`, `infrastructure/staging/kommodity`, `infrastructure/prod/kommodity` applies are no-ops on the subnet (delegation matches existing environments)