### PR TITLE
feat(kommodity-cluster): support custom Azure subnet CIDRs

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.0
+version: 0.27.1
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
@@ -49,6 +49,8 @@ spec:
   {{- $isPublic := dig "ipv4" "public" false .Values.kommodity.network }}
   {{- $hasVnet := dig "ipv4" "vnet" "" .Values.kommodity.network }}
   {{- $hasSubnet := dig "ipv4" "subnet" "" .Values.kommodity.network }}
+  {{- $cpSubnetCIDR := dig "ipv4" "controlplaneSubnet" "cidrBlock" "10.0.0.0/16" .Values.kommodity.network }}
+  {{- $nodeSubnetCIDR := dig "ipv4" "nodeSubnet" "cidrBlock" "10.1.0.0/16" .Values.kommodity.network }}
   networkSpec:
     {{- /*
       Talos API (port 50000) is deliberately NOT exposed on the apiServerLB.
@@ -132,13 +134,13 @@ spec:
       - name: {{ printf "%s-controlplane-subnet" .Release.Name }}
         role: control-plane
         cidrBlocks:
-          - 10.0.0.0/16
+          - {{ $cpSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-controlplane-nsg" .Release.Name }}
       - name: {{ printf "%s-node-subnet" .Release.Name }}
         role: node
         cidrBlocks:
-          - 10.1.0.0/16
+          - {{ $nodeSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-node-nsg" .Release.Name }}
         routeTable:
@@ -163,7 +165,7 @@ spec:
       - name: {{ printf "%s-controlplane-subnet" .Release.Name }}
         role: control-plane
         cidrBlocks:
-          - 10.0.0.0/16
+          - {{ $cpSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-controlplane-nsg" .Release.Name }}
           {{- /*
@@ -203,7 +205,7 @@ spec:
       - name: {{ printf "%s-node-subnet" .Release.Name }}
         role: node
         cidrBlocks:
-          - 10.1.0.0/16
+          - {{ $nodeSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-node-nsg" .Release.Name }}
         routeTable:

--- a/charts/kommodity-cluster/tests/azure_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_cluster_test.yaml
@@ -280,6 +280,49 @@ tests:
           path: spec.networkSpec.subnets[0].cidrBlocks[0]
           value: "10.0.1.0/24"
 
+  - it: should use default subnet CIDRs when not overridden (private mode)
+    template: templates/provider/azure/cluster.yaml
+    asserts:
+      - equal:
+          path: spec.networkSpec.subnets[0].cidrBlocks[0]
+          value: 10.0.0.0/16
+        documentIndex: 0
+      - equal:
+          path: spec.networkSpec.subnets[1].cidrBlocks[0]
+          value: 10.1.0.0/16
+        documentIndex: 0
+
+  - it: should use custom subnet CIDRs when overridden (private mode)
+    template: templates/provider/azure/cluster.yaml
+    set:
+      kommodity.network.ipv4.controlplaneSubnet.cidrBlock: 10.200.48.0/24
+      kommodity.network.ipv4.nodeSubnet.cidrBlock: 10.200.49.0/24
+    asserts:
+      - equal:
+          path: spec.networkSpec.subnets[0].cidrBlocks[0]
+          value: 10.200.48.0/24
+        documentIndex: 0
+      - equal:
+          path: spec.networkSpec.subnets[1].cidrBlocks[0]
+          value: 10.200.49.0/24
+        documentIndex: 0
+
+  - it: should use custom subnet CIDRs when overridden (public mode)
+    template: templates/provider/azure/cluster.yaml
+    set:
+      kommodity.network.ipv4.public: true
+      kommodity.network.ipv4.controlplaneSubnet.cidrBlock: 10.200.48.0/24
+      kommodity.network.ipv4.nodeSubnet.cidrBlock: 10.200.49.0/24
+    asserts:
+      - equal:
+          path: spec.networkSpec.subnets[0].cidrBlocks[0]
+          value: 10.200.48.0/24
+        documentIndex: 0
+      - equal:
+          path: spec.networkSpec.subnets[1].cidrBlocks[0]
+          value: 10.200.49.0/24
+        documentIndex: 0
+
   - it: should not render for non-Azure providers
     set:
       kommodity.provider.name: Scaleway

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -156,9 +156,9 @@ kommodity:
       public: false
       # nodeCIDR is ALWAYS required on Azure: node VMs are private in both modes,
       # so the talos-cluster-proxy needs this range to identify which node IPs to
-      # route through the tunnel. It must cover the control-plane (10.0.0.0/16)
-      # and node (10.1.0.0/16) subnets the chart creates, hence the VNet supernet.
-      # Azure VNets support CIDR ranges between /8 and /29.
+      # route through the tunnel. It must cover the control-plane and node subnets
+      # the chart creates (see controlplaneSubnet / nodeSubnet below), hence the
+      # VNet supernet. Azure VNets support CIDR ranges between /8 and /29.
       nodeCIDR: 10.0.0.0/8
       # VNet — by DEFAULT you omit the `vnet:` block entirely (as here) and CAPZ
       # auto-creates `<release>-vnet` (10.0.0.0/8) in the cluster's resource group,
@@ -174,11 +174,24 @@ kommodity:
       # vnet:
       #   name: my-existing-vnet
       #   resourceGroup: my-vnet-resource-group
+      #   cidrBlocks:
+      #     - 10.200.48.0/20
       # subnet:
       #   # Optional: Override the single-subnet path (for BYO-subnet scenarios).
       #   # When omitted, the chart creates a controlplane and a node subnet.
       #   name: my-subnet
       #   cidrBlock: 10.200.0.0/24
+      #
+      # Subnet CIDRs — by DEFAULT the chart uses 10.0.0.0/16 (controlplane) and
+      # 10.1.0.0/16 (node), matching the VNet default of 10.0.0.0/8. Override
+      # these when the defaults overlap other clusters' node CIDRs (the
+      # talos-cluster-proxy CIDR registry rejects overlapping ranges), or when
+      # you need a smaller VNet (e.g. /20 instead of /8). The controlplane and
+      # node subnets must both fit within the VNet CIDR.
+      # controlplaneSubnet:
+      #   cidrBlock: 10.200.48.0/24
+      # nodeSubnet:
+      #   cidrBlock: 10.200.49.0/24
 
   controlplane:
     replicas: 1


### PR DESCRIPTION
## Summary

Adds optional `network.ipv4.controlplaneSubnet.cidrBlock` and `network.ipv4.nodeSubnet.cidrBlock` values to the Azure cluster template, allowing custom subnet CIDRs instead of the hardcoded `10.0.0.0/16` / `10.1.0.0/16` defaults.

## Why

The talos-cluster-proxy CIDR registry rejects overlapping ranges. The default Azure VNet (`10.0.0.0/8`) and subnets (`10.0.0.0/16`, `10.1.0.0/16`) overlap with Scaleway clusters using `10.200.x.x/20` ranges, breaking the proxy tunnel that the TalosControlPlane controller uses to reach nodes for health checks. With this change, Azure clusters can use a non-overlapping CIDR range (e.g. `10.200.48.0/20` VNet, `10.200.48.0/24` CP subnet, `10.200.49.0/24` node subnet) that matches their `nodeCIDR` annotation.

Works in both public and private mode. Defaults are unchanged — existing clusters are not affected.
