### PR TITLE
fix(combinedserver): revert h2c to x/net to stop memory leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/client/v3 v3.6.4
 	go.uber.org/zap v1.27.1
+	golang.org/x/net v0.57.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -61,7 +62,6 @@ require (
 
 require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 )
 

--- a/pkg/combinedserver/server.go
+++ b/pkg/combinedserver/server.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/kommodity-io/kommodity/pkg/logging"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c" //nolint:staticcheck // PLA-6517: stdlib replacement leaks
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -148,18 +150,18 @@ func (s *server) ListenAndServe(ctx context.Context) error {
 		}
 	})
 
-	// Create HTTP server with unencrypted HTTP/2 (h2c) support via the
-	// Protocols field (replaces the deprecated golang.org/x/net/http2/h2c).
-	protocols := &http.Protocols{}
-	protocols.SetHTTP1(true)
-	protocols.SetHTTP2(true)
-	protocols.SetUnencryptedHTTP2(true)
-
+	// Create HTTP server with h2c support for HTTP/2 without TLS.
+	// NOTE: we intentionally use golang.org/x/net/http2/h2c instead of the
+	// stdlib http.Server.Protocols.SetUnencryptedHTTP2 path. The stdlib
+	// bundled http2 server leaks memory on long-lived HTTP/2 watch streams
+	// proxied through httputil.ReverseProxy (orphaned handler goroutines on
+	// RST_STREAM), causing a ~30-50 MiB/hour OOM-after-~24h sawtooth on the
+	// Azure Container App (ingress transport = http2 -> prior-knowledge h2c).
+	// See PLA-6517. x/net's http2.Server does not exhibit the leak.
 	s.httpServer = &http.Server{
 		Addr:              ":" + strconv.Itoa(s.Port),
-		Handler:           mixedHandler,
+		Handler:           h2c.NewHandler(mixedHandler, &http2.Server{}), //nolint:staticcheck // PLA-6517
 		ReadHeaderTimeout: 1 * time.Second,
-		Protocols:         protocols,
 	}
 
 	logger.Info("Starting combined HTTP/gRPC server", zap.Int("port", s.Port))

--- a/pkg/combinedserver/server.go
+++ b/pkg/combinedserver/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kommodity-io/kommodity/pkg/logging"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c" //nolint:staticcheck // PLA-6517: stdlib replacement leaks
+	"golang.org/x/net/http2/h2c" //nolint:staticcheck // stdlib replacement leaks
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -157,10 +157,9 @@ func (s *server) ListenAndServe(ctx context.Context) error {
 	// proxied through httputil.ReverseProxy (orphaned handler goroutines on
 	// RST_STREAM), causing a ~30-50 MiB/hour OOM-after-~24h sawtooth on the
 	// Azure Container App (ingress transport = http2 -> prior-knowledge h2c).
-	// See PLA-6517. x/net's http2.Server does not exhibit the leak.
 	s.httpServer = &http.Server{
 		Addr:              ":" + strconv.Itoa(s.Port),
-		Handler:           h2c.NewHandler(mixedHandler, &http2.Server{}), //nolint:staticcheck // PLA-6517
+		Handler:           h2c.NewHandler(mixedHandler, &http2.Server{}), //nolint:staticcheck
 		ReadHeaderTimeout: 1 * time.Second,
 	}
 


### PR DESCRIPTION
v0.153.0 (#418) switched the combinedserver's unencrypted HTTP/2 (h2c)
layer from golang.org/x/net/http2/h2c.NewHandler to the stdlib
http.Server.Protocols.SetUnencryptedHTTP2 path. Azure Container Apps
ingress is hardcoded to transport="http2" (since v0.104.0), so all
external traffic — including long-lived controller/informer WATCH streams
— reaches the combinedserver as prior-knowledge h2c, putting the stdlib
bundled http2 server on the hot path.

After the v0.153.0 deploy (Jul 30 14:18 UTC), kommodity-dev-app began
exhibiting a ~30-50 MiB/hour memory climb from ~700 MiB to the 2Gi limit,
followed by OOM-kill and restart — a daily sawtooth that did not exist
under x/net's http2.Server for the prior 5 months. The Go toolchain
(go 1.26.1) was unchanged across the boundary, isolating the regression
to the x/net -> stdlib http2 swap.

The reverse proxy (pkg/server/proxy.go) is a plain
httputil.NewSingleHostReverseProxy with a default http.Transport and no
FlushInterval/disconnect handling; it relies on r.Context() cancellation
to abort upstream watches on downstream RST_STREAM. The stdlib bundled
http2 server does not propagate stream-reset to request-context
cancellation as reliably as x/net, orphaning watch handler goroutines and
upstream HTTP/2 streams + buffers that accumulate until OOM.

Revert only the live combinedserver path (pkg/libkapi is dead code,
unimported by the binary, so its parallel migration is left untouched).
//nolint:staticcheck marks the intentionally-deprecated h2c usage with a
PLA-6517 reason since the stdlib replacement leaks.

Investigation: PLA-6517
Signed-off-by: Paul Thuriot <pth@corti.ai>
