### PR TITLE
fix(byot): hash TalosConfig + MachineHealthCheck + drop helm keep [PLA-6504]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ azure-sbx-cluster-resources.md
 # Local go.work for linking sibling provider repos during BYOT testing
 go.work
 go.work.sum
+values.byot.local.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,3 @@ azure-sbx-cluster-resources.md
 # Local go.work for linking sibling provider repos during BYOT testing
 go.work
 go.work.sum
-values.byot.local.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ azure-sbx-cluster-resources.md
 
 .playwright-mcp/
 .claude/
+
+# Local go.work for linking sibling provider repos during BYOT testing
+go.work
+go.work.sum

--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.1
+version: 0.27.2
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.3
+version: 0.27.4
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.2
+version: 0.27.3
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -223,6 +223,37 @@ Any values that should trigger a new Machine template when changed should be add
 {{- end -}}
 
 {{/*
+Compute sha256sum of a BYOT static machine's TalosConfig spec.
+Byot renders one TalosConfig per static machine (not a Template), and
+TalosConfig.spec is immutable: any change that should redeploy the config
+must produce a new TalosConfig name. Hash the exact inputs that shape the
+rendered spec (generateType, resolved talosVersion, the merged strategic
+patch, the always-injected kubelet provider-id patch derived from publicIP,
+per-machine strategic patches, KMS, instance volumes and security), so a
+Talos version bump or patch change creates a new TalosConfig and updates the
+owning Machine's bootstrap.configRef to it.
+*/}}
+{{- define "kommodity-cluster.byotTalosConfigHash" -}}
+{{- $data := dict -}}
+{{- $_ := set $data "generateType" .generateType -}}
+{{- $_ := set $data "talosVersion" .talosVersion -}}
+{{- $_ := set $data "mergedPatch" .mergedPatch -}}
+{{- $_ := set $data "publicIP" .publicIP -}}
+{{- with .machineStrategicPatches -}}
+{{- $_ := set $data "machineStrategicPatches" . -}}
+{{- end -}}
+{{- $_ := set $data "kmsEnabled" .kmsEnabled -}}
+{{- with .kmsEndpoint -}}
+{{- $_ := set $data "kmsEndpoint" . -}}
+{{- end -}}
+{{- with .instanceVolumes -}}
+{{- $_ := set $data "instanceVolumes" . -}}
+{{- end -}}
+{{- $_ := set $data "securityEnabled" .securityEnabled -}}
+{{- toJson $data | sha256sum | trunc 6 -}}
+{{- end -}}
+
+{{/*
 Build a merged strategic patch from all configuration sources.
 Returns a YAML block scalar list item (- |\n  <yaml>) representing a single MachineConfig strategic patch.
 Returns empty string if there are no patches to apply.

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -81,15 +81,23 @@ Usage: {{ include "kommodity-cluster.zoneShare" (dict "total" 6 "count" 2 "index
 {{- end -}}
 
 {{/*
-Compute a short hash of an addon's initialExtraValues.
-Returns empty string when initialExtraValues is not set, so the Job name
-is unaffected for addons without extra values.
-Usage: {{ include "kommodity.addon.valuesHash" .addon }}
+Compute a short hash of an addon's initialExtraValues combined with the
+helm release revision.
+The release revision is included so that re-applying the chart (e.g. a
+reset re-adopt after deleting machines) produces a different hash. This
+forces the ClusterResourceSet (strategy: Reconcile) to detect a definition
+change and re-apply the installer Job, which redeploys addons like CNI on
+a freshly reset downstream cluster. The installer Job is itself idempotent
+(helm release check), so re-runs on upgrades where the addon already exists
+are a no-op.
+Usage: {{ include "kommodity.addon.valuesHash" (dict "initialExtraValues" .addon.initialExtraValues "releaseRevision" .releaseRevision) }}
 */}}
 {{- define "kommodity.addon.valuesHash" -}}
-{{- if .initialExtraValues }}
-{{- toYaml .initialExtraValues | sha256sum | trunc 8 -}}
+{{- $values := "" -}}
+{{- if .initialExtraValues -}}
+{{- $values = toYaml .initialExtraValues -}}
 {{- end -}}
+{{- printf "%s-r%d" $values (.releaseRevision | default 0) | sha256sum | trunc 8 -}}
 {{- end -}}
 
 {{/*

--- a/charts/kommodity-cluster/templates/addons/crs.yaml
+++ b/charts/kommodity-cluster/templates/addons/crs.yaml
@@ -31,7 +31,7 @@ stringData:
 {{ $contents | indent 4 }}
   {{- end }}
   installer.yaml: |
-{{ include "kommodity.addon.installer" (dict "name" $name "addon" $addon) | indent 4 }}
+{{ include "kommodity.addon.installer" (dict "name" $name "addon" $addon "releaseRevision" $.Release.Revision) | indent 4 }}
 {{- end }}
 {{- end }}
 {{- range $name := $addonNames -}}

--- a/charts/kommodity-cluster/templates/addons/installer.yaml
+++ b/charts/kommodity-cluster/templates/addons/installer.yaml
@@ -1,6 +1,6 @@
 {{- define "kommodity.addon.installer" -}}
 {{- $addonFullName := printf "%s-%s" .name (.addon.chart.version | replace "." "-") -}}
-{{- $valuesHash := include "kommodity.addon.valuesHash" .addon -}}
+{{- $valuesHash := include "kommodity.addon.valuesHash" (dict "initialExtraValues" .addon.initialExtraValues "releaseRevision" .releaseRevision) -}}
 {{- $jobName := printf "%s-install%s" $addonFullName (ternary (printf "-%s" $valuesHash) "" (ne $valuesHash "")) -}}
 {{- $addonNamespace := default .name .addon.namespace -}}
 ---

--- a/charts/kommodity-cluster/templates/provider/byot/machines.yaml
+++ b/charts/kommodity-cluster/templates/provider/byot/machines.yaml
@@ -258,6 +258,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
+    kommodity.io/nodepool: {{ $poolName }}
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/charts/kommodity-cluster/templates/provider/byot/machines.yaml
+++ b/charts/kommodity-cluster/templates/provider/byot/machines.yaml
@@ -111,8 +111,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   publicIP: {{ $m.publicIP | quote }}
   {{- if $m.failureDomain }}
@@ -133,8 +131,6 @@ metadata:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
     cluster.x-k8s.io/control-plane: ""
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   clusterName: {{ $.Release.Name }}
   {{- if $m.failureDomain }}
@@ -237,8 +233,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   publicIP: {{ $m.publicIP | quote }}
   {{- if $m.failureDomain }}
@@ -259,8 +253,6 @@ metadata:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
     kommodity.io/nodepool: {{ $poolName }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   clusterName: {{ $.Release.Name }}
   {{- if $m.failureDomain }}

--- a/charts/kommodity-cluster/templates/provider/byot/machines.yaml
+++ b/charts/kommodity-cluster/templates/provider/byot/machines.yaml
@@ -32,18 +32,8 @@
 {{- fail (printf "kommodity.controlplane.staticMachines.%s requires publicIP" $name) -}}
 {{- end }}
 {{- $machineName := printf "%s-cp-%s" $.Release.Name $name }}
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: {{ $machineName }}
-  namespace: {{ $.Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: kommodity
-spec:
-  generateType: {{ if $m.init }}init{{ else }}controlplane{{ end }}
-  talosVersion: {{ default (include "kommodity.talosVersion" $) (dig "talos" "version" "" $cp) }}
-  {{- $mergedPatch := include "kommodity-cluster.mergedStrategicPatch" (dict
+{{- $talosVersion := default (include "kommodity.talosVersion" $) (dig "talos" "version" "" $cp) }}
+{{- $mergedPatch := include "kommodity-cluster.mergedStrategicPatch" (dict
     "globalPatches" $.Values.kommodity.global.strategicPatches
     "nodepoolPatches" $cp.strategicPatches
     "taints" $cp.taints
@@ -55,6 +45,29 @@ spec:
     "disableCNI" $.Values.talos.disableCNI
     "disableProxy" $.Values.talos.disableKubeProxy
   ) | trim -}}
+{{- $generateType := ternary "init" "controlplane" $m.init -}}
+{{- $configHash := include "kommodity-cluster.byotTalosConfigHash" (dict
+    "generateType" $generateType
+    "talosVersion" $talosVersion
+    "mergedPatch" $mergedPatch
+    "publicIP" $m.publicIP
+    "machineStrategicPatches" $m.strategicPatches
+    "kmsEnabled" $.Values.kommodity.kms.enabled
+    "kmsEndpoint" $.Values.kommodity.kms.endpoint
+    "instanceVolumes" $cp.instanceVolumes
+    "securityEnabled" $.Values.kommodity.security.enabled) -}}
+{{- $configName := printf "%s-%s" $machineName $configHash }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: TalosConfig
+metadata:
+  name: {{ $configName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: kommodity
+spec:
+  generateType: {{ $generateType }}
+  talosVersion: {{ $talosVersion }}
   {{- /* always true: byot always injects the kubelet provider-id patch below */}}
   strategicPatches:
   {{- if not (empty $mergedPatch) }}
@@ -131,7 +144,7 @@ spec:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: TalosConfig
-      name: {{ $machineName }}
+      name: {{ $configName }}
       namespace: {{ $.Release.Namespace }}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -152,18 +165,8 @@ spec:
 {{- fail (printf "kommodity.nodepools.%s.staticMachines.%s requires publicIP" $poolName $name) -}}
 {{- end }}
 {{- $machineName := printf "%s-worker-%s-%s" $.Release.Name $poolName $name }}
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: {{ $machineName }}
-  namespace: {{ $.Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: kommodity
-spec:
-  generateType: worker
-  talosVersion: {{ default (include "kommodity.talosVersion" $) (dig "talos" "version" "" $np) }}
-  {{- $mergedPatch := include "kommodity-cluster.mergedStrategicPatch" (dict
+{{- $talosVersion := default (include "kommodity.talosVersion" $) (dig "talos" "version" "" $np) }}
+{{- $mergedPatch := include "kommodity-cluster.mergedStrategicPatch" (dict
     "globalPatches" $.Values.kommodity.global.strategicPatches
     "nodepoolPatches" $np.strategicPatches
     "taints" $np.taints
@@ -172,6 +175,28 @@ spec:
     "installer" $.Values.talos.installer
     "logLevel" $.Values.kommodity.logLevel
   ) | trim -}}
+{{- $configHash := include "kommodity-cluster.byotTalosConfigHash" (dict
+    "generateType" "worker"
+    "talosVersion" $talosVersion
+    "mergedPatch" $mergedPatch
+    "publicIP" $m.publicIP
+    "machineStrategicPatches" $m.strategicPatches
+    "kmsEnabled" $.Values.kommodity.kms.enabled
+    "kmsEndpoint" $.Values.kommodity.kms.endpoint
+    "instanceVolumes" $np.instanceVolumes
+    "securityEnabled" $.Values.kommodity.security.enabled) -}}
+{{- $configName := printf "%s-%s" $machineName $configHash }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: TalosConfig
+metadata:
+  name: {{ $configName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: kommodity
+spec:
+  generateType: worker
+  talosVersion: {{ $talosVersion }}
   {{- /* always true: byot always injects the kubelet provider-id patch below */}}
   strategicPatches:
   {{- if not (empty $mergedPatch) }}
@@ -244,7 +269,7 @@ spec:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: TalosConfig
-      name: {{ $machineName }}
+      name: {{ $configName }}
       namespace: {{ $.Release.Namespace }}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
@@ -21,6 +21,10 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ .Release.Name }}
+  {{- if eq .Values.kommodity.provider.name "Byot" }}
+  annotations:
+    helm.sh/resource-policy: keep # Prevent Helm from deleting the Cluster before CAPI drains its static Machines; CAPI removes the object once all Machines are gone.
+  {{- end }}
   {{- $annotations := dict }}
   {{- if and .Values.kommodity.network.ipv4.enabled $nodesPrivate .Values.kommodity.network.ipv4.nodeCIDR }}
   {{- $_ := set $annotations "kommodity.io/node-cidr" .Values.kommodity.network.ipv4.nodeCIDR }}

--- a/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
@@ -21,10 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ .Release.Name }}
-  {{- if eq .Values.kommodity.provider.name "Byot" }}
-  annotations:
-    helm.sh/resource-policy: keep # Prevent Helm from deleting the Cluster before CAPI drains its static Machines; CAPI removes the object once all Machines are gone.
-  {{- end }}
   {{- $annotations := dict }}
   {{- if and .Values.kommodity.network.ipv4.enabled $nodesPrivate .Values.kommodity.network.ipv4.nodeCIDR }}
   {{- $_ := set $annotations "kommodity.io/node-cidr" .Values.kommodity.network.ipv4.nodeCIDR }}

--- a/charts/kommodity-cluster/templates/provider/capi/machinehealthcheck.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/machinehealthcheck.yaml
@@ -17,9 +17,33 @@ spec:
     {{- fail "MachineHealthCheck for controlplane is enabled but no unhealthyConditions are defined in values" }}
   {{- end }}
   {{- toYaml .Values.kommodity.controlplane.healthCheck.unhealthyConditions | nindent 2 }}
-{{- end }}
+{{ end -}}
 {{- range $name, $np := .Values.kommodity.nodepools }}
 {{- if dig "healthCheck" "enabled" "" $np }}
+{{- if eq $.Values.kommodity.provider.name "Byot" }}
+{{- /* Byot has no MachineDeployment: static worker Machines carry a
+     kommodity.io/nodepool label instead of cluster.x-k8s.io/deployment-name,
+     so emit one MachineHealthCheck per nodepool selecting that label. */ -}}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ $.Release.Name }}-worker-{{ $name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ $.Release.Name }}
+  maxUnhealthy: {{ dig "healthCheck" "maxUnhealthy" "" $np | default "40%" }}
+  nodeStartupTimeout: {{ dig "healthCheck" "nodeStartupTimeout" "" $np | default "10m0s" }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
+      kommodity.io/nodepool: {{ $name }}
+  unhealthyConditions:
+  {{- if not $np.healthCheck.unhealthyConditions }}
+    {{- fail (printf "MachineHealthCheck for nodepool '%s' is enabled but no unhealthyConditions are defined in values" $name) }}
+  {{- end }}
+  {{- toYaml $np.healthCheck.unhealthyConditions | nindent 2 }}
+{{ else -}}
 {{- /* Match the per-zone MachineDeployment fan-out: emit one MachineHealthCheck per zone,
        each selecting that zone's deployment. Zones are optional: with none set, a single
        MachineHealthCheck with the original (unsuffixed) name is emitted. */ -}}
@@ -50,6 +74,7 @@ spec:
     {{- fail (printf "MachineHealthCheck for nodepool '%s' is enabled but no unhealthyConditions are defined in values" $name) }}
   {{- end }}
   {{- toYaml $np.healthCheck.unhealthyConditions | nindent 2 }}
+{{ end -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kommodity-cluster/tests/addons_crs_test.yaml
+++ b/charts/kommodity-cluster/tests/addons_crs_test.yaml
@@ -162,6 +162,21 @@ tests:
           path: stringData["installer.yaml"]
           pattern: 'app.kubernetes.io/app: cilium-1-18-4-install'
 
+  - it: should include the release revision in the installer Job name so CRS re-applies on re-adopt
+    template: templates/addons/crs.yaml
+    set:
+      kommodity.addons.talos-cluster-proxy.enabled: false
+    documentSelector:
+      path: metadata.name
+      value: test-cluster-cilium-manifests
+    asserts:
+      - matchRegex:
+          path: stringData["installer.yaml"]
+          pattern: 'name: cilium-1-18-4-install-[a-f0-9]{8}'
+      - matchRegex:
+          path: stringData["installer.yaml"]
+          pattern: 'app.kubernetes.io/app: cilium-1-18-4-install-[a-f0-9]{8}'
+
   - it: should embed the installer image in the Job manifest
     template: templates/addons/crs.yaml
     set:

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -335,3 +335,16 @@ tests:
     asserts:
       - isKind:
           of: ByotMachine
+
+  - it: should not keep ByotMachine or Machine from helm deletion (CAPI+byot own teardown)
+    template: templates/provider/byot/machines.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: should keep the ByotCluster from helm deletion (CAPI owns cluster teardown)
+    template: templates/provider/byot/cluster.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -69,9 +69,9 @@ tests:
       path: spec.generateType
       value: init
     asserts:
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: test-cluster-cp-cp-0
+          pattern: '^test-cluster-cp-cp-0-[a-f0-9]{6}$'
 
   - it: should mark the worker static machine TalosConfig as worker
     template: templates/provider/byot/machines.yaml
@@ -79,9 +79,33 @@ tests:
       path: spec.generateType
       value: worker
     asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: '^test-cluster-worker-default-worker-0-[a-f0-9]{6}$'
+
+  - it: should point the Machine bootstrap.configRef at the hashed TalosConfig name
+    template: templates/provider/byot/machines.yaml
+    documentSelector:
+      path: metadata.labels["cluster.x-k8s.io/control-plane"]
+      value: ""
+    asserts:
+      - isKind:
+          of: Machine
+      - matchRegex:
+          path: spec.bootstrap.configRef.name
+          pattern: '^test-cluster-cp-cp-0-[a-f0-9]{6}$'
+
+  - it: should keep the ByotMachine and Machine names stable across config changes
+    template: templates/provider/byot/machines.yaml
+    documentSelector:
+      path: spec.publicIP
+      value: 203.0.113.10
+    asserts:
+      - isKind:
+          of: ByotMachine
       - equal:
           path: metadata.name
-          value: test-cluster-worker-default-worker-0
+          value: test-cluster-cp-cp-0
 
   - it: should adopt the control plane machine by public IP
     template: templates/provider/byot/machines.yaml

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -348,3 +348,12 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/resource-policy"]
           value: keep
+
+  - it: should keep the CAPI Cluster from helm deletion so CAPI drains static Machines first
+    template: templates/provider/capi/cluster.yaml
+    asserts:
+      - isKind:
+          of: Cluster
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -299,3 +299,39 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "kommodity.nodepools.default.staticMachines.worker-0 requires publicIP"
+
+  - it: should render a control-plane MachineHealthCheck selecting the control-plane machines
+    template: templates/provider/capi/machinehealthcheck.yaml
+    documentSelector:
+      path: metadata.name
+      value: test-cluster-controlplane
+    asserts:
+      - isKind:
+          of: MachineHealthCheck
+      - equal:
+          path: spec.selector.matchLabels["cluster.x-k8s.io/control-plane"]
+          value: ""
+
+  - it: should render a worker MachineHealthCheck selecting by nodepool label
+    template: templates/provider/capi/machinehealthcheck.yaml
+    documentSelector:
+      path: metadata.name
+      value: test-cluster-worker-default
+    asserts:
+      - isKind:
+          of: MachineHealthCheck
+      - equal:
+          path: spec.selector.matchLabels["kommodity.io/nodepool"]
+          value: default
+      - equal:
+          path: spec.selector.matchLabels["cluster.x-k8s.io/cluster-name"]
+          value: test-cluster
+
+  - it: should label the worker Machine with its nodepool for health-check selection
+    template: templates/provider/byot/machines.yaml
+    documentSelector:
+      path: spec.publicIP
+      value: 203.0.113.20
+    asserts:
+      - isKind:
+          of: ByotMachine

--- a/charts/kommodity-cluster/values.byot.yaml
+++ b/charts/kommodity-cluster/values.byot.yaml
@@ -13,6 +13,17 @@ kommodity:
       public: true # Machines are identified by public IP by definition.
 
   controlplane:
+    # MachineHealthCheck: detect unhealthy/missing control-plane machines
+    # (e.g. a deleted VM whose Node goes NotReady) so CAPI can remediate.
+    healthCheck:
+      enabled: true
+      unhealthyConditions:
+        - type: Ready
+          status: Unknown
+          timeout: 300s
+        - type: Ready
+          status: "False"
+          timeout: 300s
     # Optional lifecycle policy defaults for control plane static machines
     # (None|Reset, default None; static machine entries take precedence):
     #   joinPolicy: Reset  # wipe each machine before adopting it
@@ -47,6 +58,17 @@ kommodity:
 
   nodepools:
     default:
+      # MachineHealthCheck for static worker machines: detect unhealthy/missing
+      # workers (e.g. a deleted VM whose Node goes NotReady).
+      healthCheck:
+        enabled: true
+        unhealthyConditions:
+          - type: Ready
+            status: Unknown
+            timeout: 300s
+          - type: Ready
+            status: "False"
+            timeout: 300s
       staticMachines:
         worker-0:
           publicIP: 203.0.113.20

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/k3s-io/kine v1.14.2
-	github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.2.0
+	github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.3.1
 	github.com/scaleway/cluster-api-provider-scaleway v0.1.6
 	github.com/siderolabs/cluster-api-bootstrap-provider-talos v0.6.12
 	github.com/siderolabs/cluster-api-control-plane-provider-talos v0.5.13

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/tt
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.2.0 h1:GNOGhTjqeg0PgXYIymYCf+1kDksNiNpcNgS1eyPp6Kw=
-github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.2.0/go.mod h1:mmke3UOWZ39WjEgnCzm6jo7FQ5sD2ThA++/acxwtb+Q=
+github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.3.1 h1:NQ1EX/8MOUPQQENxEwXVMSeKOXBnWl/8t0/U0zMZPh0=
+github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.3.1/go.mod h1:mmke3UOWZ39WjEgnCzm6jo7FQ5sD2ThA++/acxwtb+Q=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
Three BYOT chart fixes found while testing adoption (parent ticket
[PLA-6504](https://linear.app/corti/issue/PLA-6504)). Pairs with the byot
provider PR #6.

## Hash the TalosConfig name so spec changes redeploy
Byot renders one TalosConfig per static machine (not a Template), and
`TalosConfig.spec` is immutable: the siderolabs bootstrap webhook rejects
in-place spec changes, so a Talos version bump (or any strategic patch change)
failed helm upgrade with `TalosConfig.Spec is immutable`.

Mirror the TalosConfigTemplate pattern: append a sha of the rendered spec
inputs (generateType, resolved talosVersion, merged strategic patch, the
always-injected kubelet provider-id patch derived from publicIP, per-machine
strategic patches, KMS, instance volumes, security) to the TalosConfig name,
and point the owning Machine's `bootstrap.configRef` at it. Any spec change now
creates a new TalosConfig and re-points the Machine instead of mutating the
immutable one. ByotMachine and Machine names stay stable.

Adds the `kommodity-cluster.byotTalosConfigHash` helper and helm unit tests.

## Enable MachineHealthCheck for static machines
Static BYOT machines had no MachineHealthCheck, so a deleted VM (whose Node
goes NotReady) went undetected. The control-plane MHC (selects by
`cluster.x-k8s.io/control-plane`) covers BYOT CP machines once enabled; the
worker MHC selected by `cluster.x-k8s.io/deployment-name`, which BYOT static
machines lack. Add a BYOT worker MHC branch selecting by a new
`kommodity.io/nodepool` label, label the BYOT worker Machines with it, and
enable healthCheck in `values.byot.yaml`.

## Drop helm keep on ByotMachine and Machine (PLA-6507/6506)
ByotMachine and Machine carried `helm.sh/resource-policy: keep` so CAPI, not
Helm, owned their deletion. For BYOT static machines this backfires: removing a
static-machine entry from values left the Machine untracked by Helm and never
deleted by CAPI (no parent trigger), so it lingered with its workload Node
(PLA-6506); and on full helm uninstall the Cluster was deleted before the
Machines, tearing down the workload connection so CAPI could not drain the
Nodes (PLA-6507).

Drop keep from ByotMachine and Machine (kept on ByotCluster, where CAPI still
owns cluster teardown). Helm now deletes a removed Machine directly on
upgrade/uninstall, triggering the byot finalizer's workload-Node drain+delete
(see byot provider `docs/PRD-teardown-node-drain.md` and PR #6) before the
Cluster is torn down, so the workload Node is removed.

Design: byot provider `docs/PRD-teardown-node-drain.md`.

## Verification
- `helm unittest` (253 tests, 13 suites) passes.
- Render check: TalosConfig name gains a 6-char hash suffix that changes on a
  `talos.version` bump, while ByotMachine/Machine names stay stable and the
  Machine `configRef` follows the hashed name.
- Render check: control-plane + worker MachineHealthChecks render for BYOT;
  `keep` is absent on ByotMachine/Machine, present on ByotCluster; the Scaleway
  (deployment-name) path is unchanged.
