### PR TITLE
fix(libkapi): wait for webhook server readiness before starting garbage collector

### DIFF
--- a/pkg/libkapi/errors.go
+++ b/pkg/libkapi/errors.go
@@ -62,5 +62,5 @@ var (
 	// ErrGarbageCollectorWebhookNotReady is returned when WithWebhookServer
 	// was used but its TLS listener never became dialable within the
 	// garbage collector's startup readiness timeout.
-	ErrGarbageCollectorWebhookNotReady = errors.New("garbage collector: webhook server was not ready in time")
+	ErrGarbageCollectorWebhookNotReady = errors.New("garbage collector webhook server was not ready in time")
 )

--- a/pkg/libkapi/errors.go
+++ b/pkg/libkapi/errors.go
@@ -59,4 +59,8 @@ var (
 	ErrGarbageCollectorClientBuild = errors.New("failed to build garbage collector client")
 	// ErrGarbageCollectorInit is returned when the garbage collector fails to initialize.
 	ErrGarbageCollectorInit = errors.New("failed to initialize garbage collector")
+	// ErrGarbageCollectorWebhookNotReady is returned when WithWebhookServer
+	// was used but its TLS listener never became dialable within the
+	// garbage collector's startup readiness timeout.
+	ErrGarbageCollectorWebhookNotReady = errors.New("garbage collector: webhook server was not ready in time")
 )

--- a/pkg/libkapi/garbagecollector.go
+++ b/pkg/libkapi/garbagecollector.go
@@ -2,7 +2,10 @@ package libkapi
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -18,6 +21,7 @@ import (
 	"k8s.io/controller-manager/pkg/informerfactory"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 const (
@@ -52,6 +56,28 @@ const (
 	// collector because each object deletion takes two API calls. Matches the
 	// upstream kube-controller-manager behaviour.
 	gcQPSMultiplier = 2
+
+	// gcWebhookReadyTimeout bounds how long Start waits, when a webhook
+	// server was configured via WithWebhookServer, for that server's TLS
+	// listener to become dialable before giving up. controller-runtime's
+	// Manager.Start launches webhook servers before any other runnable
+	// specifically to avoid a race between conversion webhooks and cache
+	// sync (see WithGarbageCollector's doc), but that only guarantees launch
+	// order, not readiness: a webhook.Server signals "ready" to the manager
+	// the instant its goroutine is scheduled - well before it actually
+	// finishes provisioning its certificate and binding its TLS listener.
+	// Without this wait, the garbage collector's discovery-driven informers
+	// can trip a conversion webhook with a List/Watch before that listener
+	// is accepting connections, failing with "connection refused".
+	gcWebhookReadyTimeout = 30 * time.Second
+
+	// gcWebhookDialTimeout bounds a single dial attempt made while polling
+	// for the webhook server's readiness.
+	gcWebhookDialTimeout = 5 * time.Second
+
+	// gcWebhookPollInterval is how often waitForWebhookServer retries the
+	// dial while waiting for the webhook server to come up.
+	gcWebhookPollInterval = 100 * time.Millisecond
 )
 
 // GarbageCollectorConfig configures the embedded ownerReferences-based
@@ -120,12 +146,36 @@ type garbageCollectorController struct {
 	// cfg is the caller's config with every zero field already resolved to
 	// its default by WithGarbageCollector.
 	cfg GarbageCollectorConfig
+
+	// webhook is the process-wide webhook config, wired in by buildManager
+	// via setWebhookConfig (see webhookAware) after every Option has been
+	// applied. nil means WithWebhookServer was never used for this New()
+	// call, so the runner has nothing to wait for.
+	webhook *WebhookConfig
 }
+
+// webhookAware is implemented by Controllers that need to know, before
+// their own SetupWithManager runs, whether WithWebhookServer was used for
+// this New() call and where its listener binds. This can't be captured
+// inside WithGarbageCollector's own Option closure: Options run in the
+// caller-supplied order, so a WithWebhookServer call later in the same
+// opts list wouldn't have populated cfg.webhook yet at that point.
+// buildManager wires it in instead, once cfg is fully resolved.
+type webhookAware interface {
+	setWebhookConfig(cfg *WebhookConfig)
+}
+
+// Compile-time assertion that garbageCollectorController implements webhookAware.
+var _ webhookAware = (*garbageCollectorController)(nil)
 
 func (g *garbageCollectorController) SetupWithManager(mgr Manager) error {
 	runner := &garbageCollectorRunner{
 		restConfig: mgr.GetConfig(),
 		cfg:        g.cfg,
+	}
+
+	if g.webhook != nil {
+		runner.webhookAddr = resolvedWebhookAddr(g.webhook)
 	}
 
 	err := mgr.Add(runner)
@@ -136,23 +186,57 @@ func (g *garbageCollectorController) SetupWithManager(mgr Manager) error {
 	return nil
 }
 
+func (g *garbageCollectorController) setWebhookConfig(cfg *WebhookConfig) {
+	g.webhook = cfg
+}
+
+// resolvedWebhookAddr returns the host:port a webhook server built from cfg
+// binds to, matching the default controller-runtime itself applies
+// (webhook.DefaultPort) when cfg.Port is left at zero. Host is always
+// webhookHost (see manager.go): the manager's webhook server only ever
+// binds to loopback.
+func resolvedWebhookAddr(cfg *WebhookConfig) string {
+	port := cfg.Port
+	if port <= 0 {
+		port = webhook.DefaultPort
+	}
+
+	return net.JoinHostPort(webhookHost, strconv.Itoa(port))
+}
+
 // garbageCollectorRunner orchestrates the garbage collector lifecycle as a
 // controller-runtime manager.Runnable.
 type garbageCollectorRunner struct {
 	restConfig *restclient.Config
 	cfg        GarbageCollectorConfig
+
+	// webhookAddr is the manager's webhook server's host:port, set only
+	// when WithWebhookServer was used for this process (see
+	// garbageCollectorController.SetupWithManager). Empty means Start has
+	// nothing to wait for.
+	webhookAddr string
 }
 
 // Compile-time assertion that the runner implements manager.Runnable.
 var _ manager.Runnable = (*garbageCollectorRunner)(nil)
 
-// Start builds the typed, metadata, and discovery clients, the REST mapper,
-// the shared and metadata informer factories, and the GarbageCollector
-// itself - using ctx, the Manager's own running context, rather than one
-// captured when the Controller was set up - then runs the collector's
-// workers, its discovery resync loop, and the REST mapper refresh loop until
-// ctx is cancelled. It blocks until all background goroutines have exited.
+// Start waits for the manager's webhook server to become reachable (if one
+// was configured via WithWebhookServer - see gcWebhookReadyTimeout's doc for
+// why), then builds the typed, metadata, and discovery clients, the REST
+// mapper, the shared and metadata informer factories, and the
+// GarbageCollector itself - using ctx, the Manager's own running context,
+// rather than one captured when the Controller was set up - then runs the
+// collector's workers, its discovery resync loop, and the REST mapper
+// refresh loop until ctx is cancelled. It blocks until all background
+// goroutines have exited.
 func (r *garbageCollectorRunner) Start(ctx context.Context) error {
+	if r.webhookAddr != "" {
+		err := waitForWebhookServer(ctx, r.webhookAddr, gcWebhookReadyTimeout)
+		if err != nil {
+			return err
+		}
+	}
+
 	clients, err := newGCClients(r.restConfig)
 	if err != nil {
 		return err
@@ -242,6 +326,55 @@ func newGCClients(restConfig *restclient.Config) (*gcClients, error) {
 		discovery:  discoveryClient,
 		restMapper: restMapper,
 	}, nil
+}
+
+// waitForWebhookServer blocks until a TLS handshake against addr succeeds,
+// polling every gcWebhookPollInterval, or returns ErrGarbageCollectorWebhookNotReady
+// once timeout elapses or ctx is cancelled, whichever comes first. It mirrors
+// webhook.DefaultServer's own StartedChecker dial
+// (sigs.k8s.io/controller-runtime/pkg/webhook, server.go): InsecureSkipVerify
+// is safe here because the goal is only to confirm the listener is accepting
+// TLS connections at all, never to validate or use the self-signed
+// certificate's identity.
+func waitForWebhookServer(ctx context.Context, addr string, timeout time.Duration) error {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: gcWebhookDialTimeout},
+		//nolint:gosec // dial-only readiness probe against our own loopback webhook server; no data is exchanged or trusted.
+		Config: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	ticker := time.NewTicker(gcWebhookPollInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+
+	for {
+		dialCtx, dialCancel := context.WithTimeout(waitCtx, gcWebhookDialTimeout)
+		conn, err := dialer.DialContext(dialCtx, "tcp", addr)
+
+		dialCancel()
+
+		if err == nil {
+			closeErr := conn.Close()
+			if closeErr != nil {
+				return fmt.Errorf("failed to close webhook readiness probe connection: %w", closeErr)
+			}
+
+			return nil
+		}
+
+		lastErr = err
+
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("%w: timed out after %s dialing %s: %w",
+				ErrGarbageCollectorWebhookNotReady, timeout, addr, lastErr)
+		case <-ticker.C:
+		}
+	}
 }
 
 // runGCRESTMapperReset resets restMapper every period until ctx is done.

--- a/pkg/libkapi/garbagecollector.go
+++ b/pkg/libkapi/garbagecollector.go
@@ -3,6 +3,7 @@ package libkapi
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -330,8 +331,10 @@ func newGCClients(restConfig *restclient.Config) (*gcClients, error) {
 
 // waitForWebhookServer blocks until a TLS handshake against addr succeeds,
 // polling every gcWebhookPollInterval, or returns ErrGarbageCollectorWebhookNotReady
-// once timeout elapses or ctx is cancelled, whichever comes first. It mirrors
-// webhook.DefaultServer's own StartedChecker dial
+// once timeout elapses or ctx is cancelled, whichever comes first - the
+// error message distinguishes the two cases so a cancelled parent ctx
+// (e.g. manager shutdown while still waiting) doesn't get logged as a
+// timeout. It mirrors webhook.DefaultServer's own StartedChecker dial
 // (sigs.k8s.io/controller-runtime/pkg/webhook, server.go): InsecureSkipVerify
 // is safe here because the goal is only to confirm the listener is accepting
 // TLS connections at all, never to validate or use the self-signed
@@ -370,8 +373,13 @@ func waitForWebhookServer(ctx context.Context, addr string, timeout time.Duratio
 
 		select {
 		case <-waitCtx.Done():
-			return fmt.Errorf("%w: timed out after %s dialing %s: %w",
-				ErrGarbageCollectorWebhookNotReady, timeout, addr, lastErr)
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("%w: timed out after %s dialing %s: %w",
+					ErrGarbageCollectorWebhookNotReady, timeout, addr, lastErr)
+			}
+
+			return fmt.Errorf("%w: context canceled while dialing %s: %w",
+				ErrGarbageCollectorWebhookNotReady, addr, lastErr)
 		case <-ticker.C:
 		}
 	}

--- a/pkg/libkapi/garbagecollector_test.go
+++ b/pkg/libkapi/garbagecollector_test.go
@@ -2,6 +2,7 @@ package libkapi_test
 
 import (
 	"context"
+	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -48,12 +49,39 @@ func TestServerEndToEnd_WithGarbageCollector(t *testing.T) {
 
 	kubeClient := startGCTestServer(t)
 
-	owner := createGCConfigMap(t, kubeClient, "gc-owner", nil)
+	assertOwnerDeletionCascades(t, kubeClient, "gc-owner", "gc-dependent")
+}
+
+// TestServerEndToEnd_WithGarbageCollector_AndWebhookServer verifies that
+// WithGarbageCollector and WithWebhookServer can be combined without the
+// garbage collector's startup racing the webhook server's TLS listener (see
+// waitForWebhookServer's doc in garbagecollector.go, and
+// TestWaitForWebhookServer_BlocksUntilDialable for the isolated ordering
+// proof): the server must start and become healthy, the registered webhook
+// handler must be reachable, and the collector must still delete a
+// dependent whose owner is removed - end-to-end evidence the readiness wait
+// doesn't deadlock or break either feature.
+func TestServerEndToEnd_WithGarbageCollector_AndWebhookServer(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := startGCWebhookTestServer(t)
+
+	assertOwnerDeletionCascades(t, kubeClient, "gc-webhook-owner", "gc-webhook-dependent")
+}
+
+// assertOwnerDeletionCascades creates ownerName and dependentName as
+// ConfigMaps with a controller ownerReference from dependent to owner,
+// deletes owner, and asserts the embedded garbage collector eventually
+// deletes dependent too.
+func assertOwnerDeletionCascades(t *testing.T, kubeClient kubernetes.Interface, ownerName, dependentName string) {
+	t.Helper()
+
+	owner := createGCConfigMap(t, kubeClient, ownerName, nil)
 
 	isController := true
 	blockOwnerDeletion := true
 
-	dependent := createGCConfigMap(t, kubeClient, "gc-dependent", []metav1.OwnerReference{{
+	dependent := createGCConfigMap(t, kubeClient, dependentName, []metav1.OwnerReference{{
 		APIVersion:         "v1",
 		Kind:               "ConfigMap",
 		Name:               owner.Name,
@@ -77,6 +105,59 @@ func TestServerEndToEnd_WithGarbageCollector(t *testing.T) {
 		return apierrors.IsNotFound(getErr)
 	}, gcTestCollectionTimeout, gcTestPollInterval,
 		"expected the garbage collector to delete the dependent ConfigMap once its owner was deleted")
+}
+
+// startGCWebhookTestServer builds and starts a libkapi Server with both
+// WithGarbageCollector and WithWebhookServer enabled, waits for the server
+// to become healthy and the webhook handler to become reachable, and
+// returns a typed client talking to it. The server is shut down via
+// t.Cleanup.
+func startGCWebhookTestServer(t *testing.T) kubernetes.Interface {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	addr := libkapi.FreeAddr(t)
+	dbPath := filepath.Join(t.TempDir(), "libkapi-gc-webhook.db")
+
+	_, webhookPortStr, err := net.SplitHostPort(libkapi.FreeAddr(t))
+	require.NoError(t, err)
+
+	server, err := libkapi.New(ctx,
+		libkapi.WithAddr(addr),
+		libkapi.WithStorage("sqlite://"+dbPath),
+		libkapi.WithController(webhookTestController{}),
+		libkapi.WithWebhookServer(libkapi.WebhookConfig{
+			Port: mustAtoi(t, webhookPortStr),
+		}),
+		libkapi.WithGarbageCollector(libkapi.GarbageCollectorConfig{
+			SyncPeriod: gcTestSyncPeriod,
+		}),
+	)
+	require.NoError(t, err)
+
+	go func() {
+		_ = server.ListenAndServe(ctx)
+	}()
+
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), gcTestShutdownTimeout)
+		defer shutdownCancel()
+
+		_ = server.Shutdown(shutdownCtx)
+	})
+
+	baseURL := "http://" + addr
+	libkapi.WaitForHealthz(t, baseURL+"/healthz")
+
+	webhookURL := "https://" + net.JoinHostPort("localhost", webhookPortStr) + "/validate"
+	waitForWebhook(t, webhookURL)
+
+	kubeClient, err := kubernetes.NewForConfig(&restclient.Config{Host: baseURL})
+	require.NoError(t, err)
+
+	return kubeClient
 }
 
 // startGCTestServer builds and starts a libkapi Server with

--- a/pkg/libkapi/garbagecollector_webhook_test.go
+++ b/pkg/libkapi/garbagecollector_webhook_test.go
@@ -111,11 +111,14 @@ func TestWaitForWebhookServer_TimesOut(t *testing.T) {
 	err := waitForWebhookServer(context.Background(), addr, gcWebhookTestShortTimeout)
 
 	require.ErrorIs(t, err, ErrGarbageCollectorWebhookNotReady)
+	assert.Contains(t, err.Error(), "timed out", "a genuine timeout should be reported as one, not a cancellation")
 }
 
 // TestWaitForWebhookServer_RespectsContextCancellation verifies a cancelled
 // ctx stops waitForWebhookServer immediately rather than waiting out the
-// full timeout.
+// full timeout, and that the resulting error is worded as a cancellation
+// rather than a timeout (they're distinct failure modes: a cancelled parent
+// ctx during manager shutdown isn't "not ready in time").
 func TestWaitForWebhookServer_RespectsContextCancellation(t *testing.T) {
 	t.Parallel()
 
@@ -128,8 +131,11 @@ func TestWaitForWebhookServer_RespectsContextCancellation(t *testing.T) {
 	err := waitForWebhookServer(ctx, addr, gcWebhookTestTimeout)
 	elapsed := time.Since(start)
 
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrGarbageCollectorWebhookNotReady)
 	assert.Less(t, elapsed, gcWebhookTestTimeout, "expected ctx cancellation to short-circuit the wait")
+	assert.Contains(t, err.Error(), "context canceled")
+	assert.NotContains(t, err.Error(), "timed out",
+		"a cancelled parent ctx should not be reported as a timeout")
 }
 
 // TestResolvedWebhookAddr verifies resolvedWebhookAddr always binds to

--- a/pkg/libkapi/garbagecollector_webhook_test.go
+++ b/pkg/libkapi/garbagecollector_webhook_test.go
@@ -1,0 +1,143 @@
+package libkapi //nolint:testpackage // exercises waitForWebhookServer/resolvedWebhookAddr, which are unexported.
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// gcWebhookTestListenDelay is how long
+	// TestWaitForWebhookServer_BlocksUntilDialable waits before actually
+	// starting the TLS listener it dials against.
+	gcWebhookTestListenDelay = 300 * time.Millisecond
+
+	// gcWebhookTestTimeout bounds waitForWebhookServer calls expected to
+	// succeed.
+	gcWebhookTestTimeout = 5 * time.Second
+
+	// gcWebhookTestShortTimeout bounds waitForWebhookServer calls expected
+	// to time out, kept short so the test itself stays fast.
+	gcWebhookTestShortTimeout = 400 * time.Millisecond
+)
+
+// TestWaitForWebhookServer_BlocksUntilDialable is the regression test for
+// the race described in WithGarbageCollector's doc: it proves
+// waitForWebhookServer does not return before a TLS listener at addr is
+// actually accepting connections - ordering, not just eventual success -
+// by starting the listener only after a deliberate delay and asserting the
+// call took at least that long.
+func TestWaitForWebhookServer_BlocksUntilDialable(t *testing.T) {
+	t.Parallel()
+
+	addr := FreeAddr(t)
+
+	certPEM, keyPEM, err := certutil.GenerateSelfSignedCertKey("localhost", nil, nil)
+	require.NoError(t, err)
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	listenerCh := make(chan net.Listener, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		time.Sleep(gcWebhookTestListenDelay)
+
+		listener, listenErr := tls.Listen("tcp", addr, tlsConfig)
+		if listenErr != nil {
+			errCh <- listenErr
+
+			return
+		}
+
+		listenerCh <- listener
+
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			// waitForWebhookServer's dial (like webhook.DefaultServer's own
+			// StartedChecker) performs a full client-side TLS handshake, so
+			// the server side must actually complete its half - closing
+			// without it would surface as a handshake EOF, not success.
+			if tlsConn, ok := conn.(*tls.Conn); ok {
+				_ = tlsConn.HandshakeContext(context.Background())
+			}
+
+			_ = conn.Close()
+		}
+	}()
+
+	start := time.Now()
+	err = waitForWebhookServer(context.Background(), addr, gcWebhookTestTimeout)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, gcWebhookTestListenDelay,
+		"expected waitForWebhookServer to block until the listener actually started")
+
+	select {
+	case listener := <-listenerCh:
+		t.Cleanup(func() {
+			_ = listener.Close()
+		})
+	case listenErr := <-errCh:
+		t.Fatalf("failed to start delayed test TLS listener: %v", listenErr)
+	default:
+		t.Fatal("expected the delayed listener to already be running once waitForWebhookServer returned")
+	}
+}
+
+// TestWaitForWebhookServer_TimesOut verifies waitForWebhookServer fails
+// loudly, wrapping ErrGarbageCollectorWebhookNotReady, instead of hanging
+// forever or silently proceeding when nothing ever listens on addr.
+func TestWaitForWebhookServer_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	addr := FreeAddr(t)
+
+	err := waitForWebhookServer(context.Background(), addr, gcWebhookTestShortTimeout)
+
+	require.ErrorIs(t, err, ErrGarbageCollectorWebhookNotReady)
+}
+
+// TestWaitForWebhookServer_RespectsContextCancellation verifies a cancelled
+// ctx stops waitForWebhookServer immediately rather than waiting out the
+// full timeout.
+func TestWaitForWebhookServer_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	addr := FreeAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := waitForWebhookServer(ctx, addr, gcWebhookTestTimeout)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, gcWebhookTestTimeout, "expected ctx cancellation to short-circuit the wait")
+}
+
+// TestResolvedWebhookAddr verifies resolvedWebhookAddr always binds to
+// webhookHost, and falls back to webhook.DefaultPort when cfg.Port is left
+// at zero.
+func TestResolvedWebhookAddr(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "127.0.0.1:9443", resolvedWebhookAddr(&WebhookConfig{}))
+	assert.Equal(t, "127.0.0.1:12345", resolvedWebhookAddr(&WebhookConfig{Port: 12345}))
+}

--- a/pkg/libkapi/manager.go
+++ b/pkg/libkapi/manager.go
@@ -77,10 +77,17 @@ func buildManager(
 		return nil, fmt.Errorf("failed to build controller manager: %w", err)
 	}
 
-	for i, c := range cfg.controllers {
-		err := c.SetupWithManager(mgr)
+	for controllerIndex, controller := range cfg.controllers {
+		// Wire in the fully-resolved webhook config (nil if WithWebhookServer
+		// was never used) before SetupWithManager runs - see webhookAware's
+		// doc for why this can't be done inside an Option closure instead.
+		if aware, ok := controller.(webhookAware); ok {
+			aware.setWebhookConfig(cfg.webhook)
+		}
+
+		err := controller.SetupWithManager(mgr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to set up controller %d: %w", i, err)
+			return nil, fmt.Errorf("failed to set up controller %d: %w", controllerIndex, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `WithGarbageCollector` + `WithWebhookServer` combined could intermittently fail with `conversion webhook for <group>/<version>, Kind=<Kind> ... connection refused` during startup: controller-runtime's `Manager.Start` guarantees webhook servers are *launched* before other runnables, but not that they're actually *ready* (TLS listener bound) by the time they're launched.
- The garbage collector's `Start` now dial-probes the manager's webhook server host:port (mirroring `webhook.DefaultServer.StartedChecker()`'s own approach) before building its discovery/typed/metadata clients and informers, bounded by a 30s timeout — failing loudly instead of hanging or silently racing.
- This is fully opt-in to the race: it only activates when `WithWebhookServer` was actually used alongside `WithGarbageCollector`. `WithGarbageCollector` used alone is unaffected.

## Root cause

See `pkg/libkapi/garbagecollector.go`'s `gcWebhookReadyTimeout` doc for the detailed explanation of the upstream controller-runtime behavior this works around.

## Test plan

- [x] `TestWaitForWebhookServer_BlocksUntilDialable` — proves the wait doesn't return before a deliberately delayed TLS listener actually starts accepting (ordering, not just eventual success)
- [x] `TestWaitForWebhookServer_TimesOut` — proves it fails loudly (wrapping `ErrGarbageCollectorWebhookNotReady`) instead of hanging when nothing ever listens
- [x] `TestWaitForWebhookServer_RespectsContextCancellation`
- [x] `TestResolvedWebhookAddr`
- [x] `TestServerEndToEnd_WithGarbageCollector_AndWebhookServer` — end-to-end: server starts, webhook handler is reachable, and the collector still deletes a dependent whose owner is removed, with both features combined
- [x] `make build`
- [x] `make lint`
- [x] `make test`
- [x] `make build-image`