### PR TITLE
fix(storage): recover from kine panic on prolonged db outage

### DIFF
--- a/pkg/libkapi/storage/errors.go
+++ b/pkg/libkapi/storage/errors.go
@@ -12,4 +12,12 @@ var (
 	// ErrKineNotReady is returned when the embedded Kine endpoint does not
 	// become ready to accept connections within the readiness timeout.
 	ErrKineNotReady = errors.New("kine did not become ready")
+	// ErrKineStartPanicked is returned when starting the embedded Kine
+	// endpoint panics instead of returning an error. This works around a bug
+	// in github.com/k3s-io/kine's generic.Open: it does not check the error
+	// from its internal connection-retry loop before continuing, so once the
+	// database stays unreachable for the whole retry window (e.g. a
+	// persistent DNS failure), it proceeds with a nil *sql.DB and panics on
+	// first use.
+	ErrKineStartPanicked = errors.New("starting embedded kine endpoint panicked")
 )

--- a/pkg/libkapi/storage/kine.go
+++ b/pkg/libkapi/storage/kine.go
@@ -89,6 +89,16 @@ func startKine(ctx context.Context,
 		}
 	}()
 
+	// endpoint.Listen can panic instead of returning an error - see
+	// ErrKineStartPanicked - if the database stays unreachable for its
+	// entire internal retry window. Recover so a prolonged outage surfaces
+	// as a normal error instead of crashing the process.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			rerr = fmt.Errorf("%w: %v", ErrKineStartPanicked, recovered)
+		}
+	}()
+
 	listenAddr := "unix://" + filepath.Join(tmpDir, kineSocketFileName)
 
 	etcdConfig, err := endpoint.Listen(ctx, endpoint.Config{

--- a/pkg/libkapi/storage/kine.go
+++ b/pkg/libkapi/storage/kine.go
@@ -18,6 +18,11 @@ import (
 
 const kineSocketFileName = "kine.sock"
 
+// endpointListen is a seam over endpoint.Listen so tests can simulate it
+// panicking (see ErrKineStartPanicked) without a real prolonged database
+// outage.
+var endpointListen = endpoint.Listen //nolint:gochecknoglobals // test seam, not mutable config.
+
 // Kine tuning defaults, mirrored from github.com/k3s-io/kine/pkg/app's CLI
 // flag defaults (pkg/app/app.go). endpoint.Listen has none of its own: it is
 // a lower-level entry point than the CLI wrapper, so callers driving it
@@ -89,19 +94,23 @@ func startKine(ctx context.Context,
 		}
 	}()
 
-	// endpoint.Listen can panic instead of returning an error - see
+	// endpointListen can panic instead of returning an error - see
 	// ErrKineStartPanicked - if the database stays unreachable for its
 	// entire internal retry window. Recover so a prolonged outage surfaces
 	// as a normal error instead of crashing the process.
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			rerr = fmt.Errorf("%w: %v", ErrKineStartPanicked, recovered)
+			if recoveredErr, ok := recovered.(error); ok {
+				rerr = fmt.Errorf("%w: %w", ErrKineStartPanicked, recoveredErr)
+			} else {
+				rerr = fmt.Errorf("%w: %v", ErrKineStartPanicked, recovered)
+			}
 		}
 	}()
 
 	listenAddr := "unix://" + filepath.Join(tmpDir, kineSocketFileName)
 
-	etcdConfig, err := endpoint.Listen(ctx, endpoint.Config{
+	etcdConfig, err := endpointListen(ctx, endpoint.Config{
 		Listener:              listenAddr,
 		Endpoint:              dbEndpoint,
 		WaitGroup:             kineWaitGroup,

--- a/pkg/libkapi/storage/kine_internal_test.go
+++ b/pkg/libkapi/storage/kine_internal_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/k3s-io/kine/pkg/endpoint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errSimulatedConnectionFailure stands in for whatever error k3s-io/kine's
+// generic.Open would have panicked with (see ErrKineStartPanicked).
+var errSimulatedConnectionFailure = errors.New("simulated connection failure")
+
+// TestStartKineRecoversFromListenPanic simulates the upstream k3s-io/kine
+// failure mode described by ErrKineStartPanicked - generic.Open proceeding
+// with a nil *sql.DB after exhausting its internal retry loop - by swapping
+// out endpointListen for a stub that panics, without waiting on a real
+// 5-minute database outage. startKine must recover and return a wrapped
+// error rather than letting the panic escape.
+//
+//nolint:paralleltest // mutates the package-level endpointListen seam that
+// storage_test.go's parallel tests call indirectly through storage.Resolve.
+func TestStartKineRecoversFromListenPanic(t *testing.T) {
+	original := endpointListen
+
+	t.Cleanup(func() { endpointListen = original })
+
+	endpointListen = func(context.Context, endpoint.Config) (endpoint.ETCDConfig, error) {
+		panic(errSimulatedConnectionFailure)
+	}
+
+	var kineWaitGroup sync.WaitGroup
+
+	endpoints, cleanup, err := startKine(context.Background(), "postgres://example", &kineWaitGroup)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrKineStartPanicked)
+	require.ErrorIs(t, err, errSimulatedConnectionFailure)
+	assert.Nil(t, endpoints)
+	assert.Nil(t, cleanup)
+}


### PR DESCRIPTION
## Summary

- A user reported kontinuum crashing with a `SIGSEGV` (`invalid memory address or nil pointer dereference`) after Postgres stayed unreachable (DNS `no such host` for the `postgres` service) for several minutes.
- Root cause is upstream: `github.com/k3s-io/kine@v1.14.2`'s `generic.Open` retries connecting for up to 300 attempts (~5 min), but never checks the final error after that loop before continuing. If the DB is still unreachable at the end of the retry window, it proceeds with a `nil *sql.DB` and panics on first use in `configureConnectionPooling` (`db.SetMaxIdleConns`) — exactly matching the reported trace.
- Since the vendored kine module can't be patched in place, `startKine` in `pkg/libkapi/storage/kine.go` now recovers from that panic and converts it into a wrapped `ErrKineStartPanicked` error, so a prolonged database outage exits cleanly with a normal log line instead of crashing the process.
- Traced through kine's internals to confirm this recovery doesn't leave a dangling panic risk: the leaked goroutine spawned by `generic.Open` before the panic point is tied to `endpoint.Listen`'s internal `context.Background()`-derived context, which never gets canceled on this path — so it just leaks harmlessly rather than panicking again later.

This does not address why `postgres` failed to resolve in the first place (that's a transient infra/DNS condition); it only prevents that condition from taking the process down with an unhelpful panic trace.

## Test plan

- [x] `go build ./...`
- [x] `go tool golangci-lint run ./...`
- [x] `go test ./...` (all packages pass, including `pkg/libkapi/storage`)
- [x] `make build` (binary builds successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)