### PR TITLE
feat(libkapi): expose storage endpoints via Ctx

### DIFF
--- a/pkg/libkapi/ctx.go
+++ b/pkg/libkapi/ctx.go
@@ -2,6 +2,7 @@ package libkapi
 
 import (
 	"net/http"
+	"slices"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -9,14 +10,16 @@ import (
 )
 
 // Ctx exposes the resources available to a ServerFactory: the server's
-// shared HTTP mux, its privileged loopback identity, and - via GRPCServer -
-// a lazily built gRPC server. New accessors can be added here over time
-// without changing ServerFactory's signature, so extending what a factory
-// can reach is never a breaking change.
+// shared HTTP mux, its privileged loopback identity, its storage backend's
+// etcd3-compatible endpoints, and - via GRPCServer - a lazily built gRPC
+// server. New accessors can be added here over time without changing
+// ServerFactory's signature, so extending what a factory can reach is never
+// a breaking change.
 type Ctx struct {
-	mux            *http.ServeMux
-	loopbackConfig *restclient.Config
-	grpcServer     *grpc.Server
+	mux              *http.ServeMux
+	loopbackConfig   *restclient.Config
+	grpcServer       *grpc.Server
+	storageEndpoints []string
 }
 
 // HTTPMux returns the server's shared HTTP mux, for mounting additional
@@ -37,6 +40,17 @@ func (c *Ctx) HTTPMux() *http.ServeMux {
 // server's loopback identity - the same reasoning as configForGC's own copy.
 func (c *Ctx) LoopbackConfig() *restclient.Config {
 	return restclient.CopyConfig(c.loopbackConfig)
+}
+
+// StorageEndpoints returns the etcd3-compatible endpoints backing the
+// server's storage - the same ones RESTOptionsGetters dial. For a Kine DSN
+// scheme (postgres/mysql/sqlite/nats), this is the private endpoint of the
+// in-process Kine gRPC server libkapi spawned; for etcd:// or unix://, the
+// endpoint given to WithStorage directly. A clone, rather than the shared
+// slice itself, is returned so a factory can't mutate the server's own
+// endpoints - the same reasoning as LoopbackConfig's own copy.
+func (c *Ctx) StorageEndpoints() []string {
+	return slices.Clone(c.storageEndpoints)
 }
 
 // GRPCServer returns the server's gRPC server, building it (and

--- a/pkg/libkapi/server.go
+++ b/pkg/libkapi/server.go
@@ -585,7 +585,11 @@ func buildDelegationChain(
 	// runServerFactories can mount it before PrepareRun runs. ListenAndServe
 	// calls PrepareRun exactly once before NonBlockingRunWithContext.
 	grpcServer, handler, err := runServerFactories(
-		cfg.serverFactories, genericServerConfig.LoopbackClientConfig, aggregatorServer.GenericAPIServer.Handler)
+		cfg.serverFactories,
+		genericServerConfig.LoopbackClientConfig,
+		storageEndpoints,
+		aggregatorServer.GenericAPIServer.Handler,
+	)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/libkapi/serverfactory.go
+++ b/pkg/libkapi/serverfactory.go
@@ -11,17 +11,18 @@ import (
 
 // ServerFactory extends the built server using whatever combination of
 // Ctx's resources it needs: register gRPC services via Ctx.GRPCServer,
-// mount HTTP routes via Ctx.HTTPMux, and/or build a privileged client from
-// Ctx.LoopbackConfig. It replaces the narrower GRPCServerFactory and
+// mount HTTP routes via Ctx.HTTPMux, build a privileged client from
+// Ctx.LoopbackConfig, and/or dial the storage backend directly via
+// Ctx.StorageEndpoints. It replaces the narrower GRPCServerFactory and
 // HTTPHandlerFactory, which remain as deprecated adapters implemented in
 // terms of WithServerFactory.
 type ServerFactory func(*Ctx) error
 
 // WithServerFactory registers factory to run once, while the server is
 // being built, against a shared Ctx exposing the HTTP mux, the gRPC server
-// (built lazily - see Ctx.GRPCServer), and the server's own loopback client
-// config. Can be passed more than once; factories run in registration
-// order against the same Ctx.
+// (built lazily - see Ctx.GRPCServer), the server's own loopback client
+// config, and its storage backend's endpoints. Can be passed more than
+// once; factories run in registration order against the same Ctx.
 func WithServerFactory(factory ServerFactory) Option {
 	return func(_ context.Context, cfg *config) error {
 		cfg.serverFactories = append(cfg.serverFactories, factory)
@@ -42,11 +43,13 @@ func WithServerFactory(factory ServerFactory) Option {
 func runServerFactories(
 	factories []ServerFactory,
 	loopbackConfig *restclient.Config,
+	storageEndpoints []string,
 	apiHandler http.Handler,
 ) (*grpc.Server, http.Handler, error) {
 	factoryCtx := &Ctx{
-		mux:            http.NewServeMux(),
-		loopbackConfig: loopbackConfig,
+		mux:              http.NewServeMux(),
+		loopbackConfig:   loopbackConfig,
+		storageEndpoints: storageEndpoints,
 	}
 
 	for i, factory := range factories {

--- a/pkg/libkapi/serverfactory_test.go
+++ b/pkg/libkapi/serverfactory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -18,8 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// serverFactoryTestShutdownTimeout bounds the server shutdown run from t.Cleanup.
-const serverFactoryTestShutdownTimeout = 10 * time.Second
+const (
+	// serverFactoryTestShutdownTimeout bounds the server shutdown run from t.Cleanup.
+	serverFactoryTestShutdownTimeout = 10 * time.Second
+	// serverFactoryTestStorageTimeout bounds dialing, and probing, the endpoint
+	// captured from Ctx.StorageEndpoints.
+	serverFactoryTestStorageTimeout = 5 * time.Second
+)
 
 // loopbackHealthServer implements grpc_health_v1.HealthServer, reporting
 // SERVING only if kubeClient (built from Ctx.LoopbackConfig by the
@@ -114,6 +120,52 @@ func TestServerEndToEnd_WithServerFactory(t *testing.T) {
 	resp, err := client.Check(callCtx, &grpc_health_v1.HealthCheckRequest{})
 	require.NoError(t, err)
 	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+// TestServerEndToEnd_CtxStorageEndpoints verifies that Ctx.StorageEndpoints
+// hands a ServerFactory real, dialable etcd3 endpoints for the server's own
+// storage backend - here, the private endpoint of the in-process Kine gRPC
+// server libkapi spawned for the sqlite:// DSN - not just a non-empty
+// slice.
+func TestServerEndToEnd_CtxStorageEndpoints(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	addr := libkapi.FreeAddr(t)
+	dbPath := filepath.Join(t.TempDir(), "libkapi-serverfactory-storage-endpoints.db")
+
+	var capturedEndpoints []string
+
+	// The server is never started: factories run - and storage is resolved,
+	// spawning Kine - during New, and canceling ctx tears that endpoint back
+	// down, so there is nothing here for ListenAndServe/Shutdown to do.
+	_, err := libkapi.New(ctx,
+		libkapi.WithAddr(addr),
+		libkapi.WithStorage("sqlite://"+dbPath),
+		libkapi.WithServerFactory(func(factoryCtx *libkapi.Ctx) error {
+			capturedEndpoints = factoryCtx.StorageEndpoints()
+
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedEndpoints, "expected at least one storage endpoint")
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   capturedEndpoints,
+		DialTimeout: serverFactoryTestStorageTimeout,
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	getCtx, getCancel := context.WithTimeout(ctx, serverFactoryTestStorageTimeout)
+	defer getCancel()
+
+	_, err = client.Get(getCtx, "libkapi-storage-endpoints-probe")
+	require.NoError(t, err, "expected StorageEndpoints to be a live, dialable etcd3 endpoint")
 }
 
 // TestNew_ServerFactoryError verifies that an error returned by a


### PR DESCRIPTION
## Summary

Part 1 of a two-part change to expose kine's gRPC endpoint through Ctx and auth-gate it in kontinuum. This PR is the `kommodity/libkapi` half only — mechanical, policy-free plumbing, no auth/proxying/interceptors.

- `libkapi.Ctx` already gives every `ServerFactory` three things via `HTTPMux()`, `LoopbackConfig()`, and `GRPCServer()` — the last one a lazily-built `*grpc.Server` multiplexed onto the same port via an h2c switch (`server.go`'s `newHTTPServer` only flips that switch if some factory actually calls `GRPCServer()`). The "single port" requirement is already solved infrastructure.
- The one missing piece: a way to reach kine's own already-running etcd3 gRPC server, which `startKine` (`pkg/libkapi/storage/kine.go`) binds to a private Unix socket that only the apiserver's internal REST storage layer dials today.
- This adds `Ctx.StorageEndpoints() []string`, threading the already-resolved `storage.Handle.Endpoints()` value (the same one `RESTOptionsGetters` use) through to `runServerFactories` and into `Ctx` at construction time — same place, same pattern as `mux`/`loopbackConfig`/`grpcServer`. Purely additive: new field, new accessor, nothing existing changes shape.
- Deliberately stops here — no auth, no proxying, no interceptors. `libkapi` hands out plumbing; `kontinuum` owns policy (part 2, a separate PR on top of this one).

Stacked on #449.

## Test plan

- [x] `make generate` (reverted the known `pkg/openapi/intstr/zz_generated.openapi.go` generator bug)
- [x] `make build`
- [x] `make lint` (0 issues)
- [x] `make test` (full suite passes)
- [x] `make build-image`
- [x] New end-to-end test `TestServerEndToEnd_CtxStorageEndpoints`: builds a real `libkapi.Server` backed by `sqlite://` (spawning an in-process Kine gRPC endpoint), captures `Ctx.StorageEndpoints()` from a `WithServerFactory` callback, and proves it's a live, dialable etcd3 endpoint via a real `clientv3.Get`.

Note: while stress-testing, found that `pkg/libkapi`'s parallel tests that call `libkapi.New()` (6 files, pre-existing, not introduced by this change) can intermittently hit a `concurrent map read and map write` panic in the shared `k8s.io/apimachinery` scheme singleton when one test's live server is still serving/watching while another test's `New()` mutates the scheme. Filed as a separate follow-up; not blocking here since `make test` passes cleanly on normal runs and the race predates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)