### PR TITLE
fix(kommodity-cluster): emit UserVolumeConfig for additionalVolumes to fix vfat/xfs mismatch

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.1
+version: 0.28.0
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/talos/configtemplate.yaml
+++ b/charts/kommodity-cluster/templates/talos/configtemplate.yaml
@@ -25,7 +25,10 @@ spec:
         "installer" $.Values.talos.installer
         "logLevel" $.Values.kommodity.logLevel
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled (gt (len (default list $np.instanceVolumes)) 0) }}
+      {{- $kmsEndpoint := "" -}}
+      {{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
+      {{- $additionalVolumesPatch := include "kommodity.talos.additionalVolumes" (dict "additionalVolumes" $np.additionalVolumes "kmsEndpoint" $kmsEndpoint) | trim -}}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled $.Values.kommodity.security.enabled (gt (len (default list $np.instanceVolumes)) 0) (not (empty $additionalVolumesPatch)) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- if not (empty $mergedPatch) }}
@@ -37,9 +40,11 @@ spec:
       {{- end }}
       {{- if $np.instanceVolumes }}
       {{- /* UserVolumeConfig for instance-local disks (not cloud-provisioned) */ -}}
-{{- $kmsEndpoint := "" -}}
-{{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
 {{- include "kommodity.talos.instanceVolumes" (dict "instanceVolumes" $np.instanceVolumes "kmsEndpoint" $kmsEndpoint "kmsEnabled" $.Values.kommodity.kms.enabled) | nindent 6 }}
+      {{- end }}
+      {{- if not (empty $additionalVolumesPatch) }}
+      {{- /* UserVolumeConfig for cloud-provisioned data disks (Azure dataDisks, etc.) */ -}}
+{{ $additionalVolumesPatch | nindent 6 }}
       {{- end }}
       {{- if $.Values.kommodity.security.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-attestation extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/controlplane.yaml
+++ b/charts/kommodity-cluster/templates/talos/controlplane.yaml
@@ -66,7 +66,10 @@ spec:
         "disableCNI" $.Values.talos.disableCNI
         "disableProxy" $.Values.talos.disableKubeProxy
       ) | trim -}}
-      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled (gt (len (default list $.Values.kommodity.controlplane.instanceVolumes)) 0) }}
+      {{- $kmsEndpoint := "" -}}
+      {{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
+      {{- $additionalVolumesPatch := include "kommodity.talos.additionalVolumes" (dict "additionalVolumes" $.Values.kommodity.controlplane.additionalVolumes "kmsEndpoint" $kmsEndpoint) | trim -}}
+      {{- $needsStrategicPatches := or (not (empty $mergedPatch)) $.Values.kommodity.kms.enabled (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled $.Values.kommodity.security.enabled (gt (len (default list $.Values.kommodity.controlplane.instanceVolumes)) 0) (not (empty $additionalVolumesPatch)) }}
       {{- if $needsStrategicPatches }}
       strategicPatches:
       {{- /* Merged MachineConfig patch (labels, taints, annotations, env, installer, OIDC, CNI, proxy, CCM, user patches) */ -}}
@@ -79,9 +82,11 @@ spec:
       {{- end }}
       {{- if $.Values.kommodity.controlplane.instanceVolumes }}
       {{- /* UserVolumeConfig for instance-local disks (not cloud-provisioned) */ -}}
-{{- $kmsEndpoint := "" -}}
-{{- if $.Values.kommodity.kms.enabled }}{{- $kmsEndpoint = $.Values.kommodity.kms.endpoint -}}{{- end -}}
 {{- include "kommodity.talos.instanceVolumes" (dict "instanceVolumes" $.Values.kommodity.controlplane.instanceVolumes "kmsEndpoint" $kmsEndpoint "kmsEnabled" $.Values.kommodity.kms.enabled) | nindent 6 }}
+      {{- end }}
+      {{- if not (empty $additionalVolumesPatch) }}
+      {{- /* UserVolumeConfig for cloud-provisioned data disks (Azure dataDisks, etc.) */ -}}
+{{ $additionalVolumesPatch | nindent 6 }}
       {{- end }}
       {{- if or (not $.Values.kommodity.network.ipv4.public) $.Values.talos.autoBootstrap.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-autobootstrap extension */ -}}

--- a/charts/kommodity-cluster/templates/talos/user-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/user-volumes.yaml
@@ -1,0 +1,56 @@
+{{/*
+Talos UserVolumeConfig documents for additionalVolumes entries.
+
+additionalVolumes provisions cloud-provider data disks (Azure dataDisks,
+Scaleway additionalVolumes) AND emits matching Talos UserVolumeConfig
+documents so Talos partitions, formats (xfs), and mounts them at
+/var/mnt/<nameSuffix>. Without this, Azure data disks arrive with a vfat
+filesystem that Talos rejects with "filesystem type mismatch: vfat != xfs".
+
+Entries without a nameSuffix are skipped (no UserVolumeConfig generated).
+On Azure, nameSuffix is already required by the AzureMachineTemplate.
+On Scaleway, nameSuffix is optional — set it to get Talos-side provisioning.
+
+An optional diskSelector field overrides the auto-generated size-based
+CEL selector. Use this when the default selector (size-based) is too
+imprecise (e.g., multiple data disks of similar size, or a local temp
+disk that matches the size threshold).
+
+See:
+  - UserVolumeConfig: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+  - Disk management:  https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
+
+Usage: {{ include "kommodity.talos.additionalVolumes" (dict "additionalVolumes" .additionalVolumes "kmsEndpoint" .kmsEndpoint) }}
+Returns empty string when additionalVolumes is not set or no entries have nameSuffix.
+*/}}
+{{- define "kommodity.talos.additionalVolumes" -}}
+{{- $volumes := .additionalVolumes -}}
+{{- $kmsEndpoint := .kmsEndpoint -}}
+{{- if $volumes -}}
+{{- range $vol := $volumes }}
+{{- if $vol.nameSuffix }}
+{{- $name := $vol.nameSuffix -}}
+{{- $selector := $vol.diskSelector -}}
+{{- if not $selector }}
+{{- $selector = printf "system_disk == false && disk.size > %vu * GB" (sub $vol.size 1) -}}
+{{- end }}
+- |
+  apiVersion: v1alpha1
+  kind: UserVolumeConfig
+  name: {{ $name }}
+  volumeType: disk
+  provisioning:
+    diskSelector:
+      match: {{ $selector | quote }}
+{{- if $kmsEndpoint }}
+  encryption:
+    provider: luks2
+    keys:
+      - slot: 0
+        kms:
+          endpoint: {{ $kmsEndpoint | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kommodity-cluster/templates/talos/user-volumes.yaml
+++ b/charts/kommodity-cluster/templates/talos/user-volumes.yaml
@@ -32,6 +32,9 @@ Returns empty string when additionalVolumes is not set or no entries have nameSu
 {{- $name := $vol.nameSuffix -}}
 {{- $selector := $vol.diskSelector -}}
 {{- if not $selector }}
+{{- if not $vol.size }}
+{{- fail "additionalVolumes[].size is required when diskSelector is not set (used to generate the disk selector CEL expression)" -}}
+{{- end }}
 {{- $selector = printf "system_disk == false && disk.size > %vu * GB" (sub $vol.size 1) -}}
 {{- end }}
 - |

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -500,3 +500,126 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "instanceVolumes[].diskSelector is required (CEL expression to match the target disk)"
+
+  # additionalVolumes UserVolumeConfig tests
+  - it: should emit UserVolumeConfig for worker additionalVolumes with nameSuffix
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "name: data"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: 'volumeType: disk'
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: 'system_disk == false && disk.size > 99u \* GB'
+
+  - it: should emit UserVolumeConfig for controlplane additionalVolumes
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.controlplane.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+    asserts:
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "name: data"
+
+  - it: should use custom diskSelector when provided
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+          diskSelector: "disk.serial.startsWith('deadbeef')"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "disk.serial.startsWith\\('deadbeef'\\)"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "system_disk"
+
+  - it: should emit KMS encryption for additionalVolumes when KMS is enabled
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.kms.enabled: true
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "kind: UserVolumeConfig"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: "provider: luks2"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[3]
+          pattern: 'endpoint: "https://kms.example.com"'
+
+  - it: should not emit encryption for additionalVolumes when KMS is disabled
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "luks2"
+
+  - it: should not emit UserVolumeConfig for additionalVolumes without nameSuffix
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - size: 50
+          type: block
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[0]
+          pattern: "UserVolumeConfig"
+
+  - it: should emit multiple UserVolumeConfig for multiple additionalVolumes
+    template: templates/talos/configtemplate.yaml
+    set:
+      kommodity.nodepools.default.additionalVolumes:
+        - nameSuffix: data
+          size: 100
+        - nameSuffix: cache
+          size: 200
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: "name: data"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[1]
+          pattern: 'disk.size > 99u \* GB'
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[2]
+          pattern: "name: cache"
+      - matchRegex:
+          path: spec.template.spec.strategicPatches[2]
+          pattern: 'disk.size > 199u \* GB'
+
+  - it: should not emit UserVolumeConfig when additionalVolumes is unset
+    template: templates/talos/configtemplate.yaml
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.template.spec.strategicPatches[0]
+          pattern: "UserVolumeConfig"

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -246,11 +246,18 @@ kommodity:
       #   # Azure template maps `size` (GB) to the CAPZ `diskSizeGB` field.
       #   # Azure-specific extras: nameSuffix (required by CAPZ), lun,
       #   # storageClassName (defaults to Premium_LRS), cachingType (optional).
+      #   # nameSuffix also doubles as the Talos volume name — when set, a
+      #   # UserVolumeConfig is emitted so Talos formats (xfs) and mounts
+      #   # the disk at /var/mnt/<nameSuffix>. Without nameSuffix, no Talos
+      #   # volume config is generated (disk is attached but unmanaged).
+      #   # Optional diskSelector overrides the auto-generated size-based
+      #   # CEL selector (useful to avoid matching Azure temp disks).
       #   - nameSuffix: data
       #     size: 100
       #     lun: 0
       #     storageClassName: Premium_LRS
       #     cachingType: ReadWrite
+      #     # diskSelector: "disk.serial.startsWith('deadbeef')"
       # instanceVolumes:
       #   # Instance-local disks that exist on the VM at boot (not provisioned via
       #   # the Azure API). E.g. the temp disk on Azure VMs (/dev/sdb on many

--- a/charts/kommodity-cluster/values.scaleway.yaml
+++ b/charts/kommodity-cluster/values.scaleway.yaml
@@ -87,9 +87,17 @@ kommodity:
         disk:
           size: 20
       # additionalVolumes:
-      #   - size: 50 # size in GB
+      #   # nameSuffix is optional on Scaleway — when set, a Talos
+      #   # UserVolumeConfig is emitted so Talos formats (xfs) and mounts
+      #   # the disk at /var/mnt/<nameSuffix>. Without nameSuffix, the disk
+      #   # is attached but Talos does not manage it.
+      #   # Optional diskSelector overrides the auto-generated size-based
+      #   # CEL selector.
+      #   - nameSuffix: data
+      #     size: 50 # size in GB
       #     type: block # optional, defaults to block (local, block, scratch)
       #     iops: 5000 # optional, only valid for block volumes (5000 or 15000)
+      #     # diskSelector: "disk.transport == 'nvme'"
       # instanceVolumes:
       #   # Instance-local disks that exist on the VM at boot (not provisioned via
       #   # the Scaleway API). E.g. the built-in scratch NVMe on H100 instances.

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -308,6 +308,14 @@ kommodity:
     #     status: "False"
     #     timeout: 300s
 
+    #   # Optional: additional data disks. When nameSuffix is set, a Talos
+    #   # UserVolumeConfig is emitted so Talos formats (xfs) and mounts
+    #   # at /var/mnt/<nameSuffix>. Optional diskSelector overrides the
+    #   # auto-generated size-based CEL selector.
+    #   additionalVolumes:
+    #     - nameSuffix: data
+    #       size: 100
+
     # instanceVolumes:
     #   # Instance-local disks that exist on the VM at boot (not provisioned via
     #   # the cloud provider's volume API). E.g. the Scaleway H100 scratch NVMe
@@ -371,6 +379,14 @@ kommodity:
     #     - type: Ready
     #       status: "False"
     #       timeout: 300s
+
+    #   # Optional: additional data disks. When nameSuffix is set, a Talos
+    #   # UserVolumeConfig is emitted so Talos formats (xfs) and mounts
+    #   # at /var/mnt/<nameSuffix>. Optional diskSelector overrides the
+    #   # auto-generated size-based CEL selector.
+    #   additionalVolumes:
+    #     - nameSuffix: data
+    #       size: 100
 
     #   # Instance-local disks (see kommodity.controlplane.instanceVolumes above)
     #   instanceVolumes:


### PR DESCRIPTION
## Summary

Azure data disks created via `additionalVolumes` arrive with a vfat filesystem that Talos rejects with `filesystem type mismatch: vfat != xfs`, causing worker nodes to fail bootstrap. The `additionalVolumes` mechanism provisions cloud-provider data disks but previously emitted no corresponding Talos volume configuration, leaving Talos unable to partition, format, or mount them.

This PR generates a Talos `UserVolumeConfig` strategic patch for each `additionalVolumes` entry that has a `nameSuffix`, so Talos formats (xfs) and mounts the disk at `/var/mnt/<nameSuffix>`.

## Changes

- **New `templates/talos/user-volumes.yaml`**: Generates `UserVolumeConfig` with `volumeType: disk` and a size-based CEL disk selector (`system_disk == false && disk.size > (size-1)u * GB`). Uses `GB` (decimal) to work with both Azure (GiB-provisioned) and Scaleway (GB-provisioned) disks. Supports an optional `diskSelector` override for cases where the auto-generated selector is too imprecise (e.g., VMs with local temp disks). When KMS is enabled, volumes are encrypted with luks2+KMS.
- **`configtemplate.yaml` / `controlplane.yaml`**: Include `additionalVolumes` `UserVolumeConfig` in strategic patches. The `$kmsEndpoint` variable is computed once and shared between `instanceVolumes` and `additionalVolumes`.
- **Chart version**: Bumped from `0.27.1` to `0.28.0`.

## Behavior

- Entries **with** `nameSuffix`: `UserVolumeConfig` is generated — Talos partitions, formats (xfs), and mounts at `/var/mnt/<nameSuffix>`. On Azure, `nameSuffix` is already required by CAPZ, so all Azure data disks get this automatically.
- Entries **without** `nameSuffix`: No `UserVolumeConfig` generated — disk is attached but unmanaged by Talos. This is backward-compatible with existing Scaleway/Kubevirt configurations that use raw block volumes (e.g., for Ceph OSDs).
- `instanceVolumes` is unchanged and coexists with `additionalVolumes`.

## Per-provider impact

| Provider | nameSuffix in machine template? | UserVolumeConfig generated? |
|----------|--------------------------------|-----------------------------|
| Azure | Required by CAPZ | Always (nameSuffix always present) |
| Scaleway | Not used by template | Only if user sets nameSuffix (opt-in) |
| Kubevirt | Not used (index-based naming) | Only if user sets nameSuffix (opt-in) |
| Docker | No additionalVolumes support | Not generated |
| BYOT | No additionalVolumes support | Not generated (guarded out) |

## Disk selector

The auto-generated selector `system_disk == false && disk.size > (size-1)u * GB` matches non-system disks by size. For most VM sizes without a local temp disk, this correctly identifies the data disk. For VMs with a local temp disk that may match the size threshold, an optional `diskSelector` field can be set to provide a more precise CEL expression (e.g., targeting by serial, transport, or dev_path).

## Verification

- 254/254 helm unit tests pass (8 new tests covering: worker/controlplane emission, custom diskSelector override, KMS encryption on/off, skip-without-nameSuffix, multiple volumes, unset additionalVolumes)
- `git diff --check` clean

```bash
make run-helm-unit-tests
# Charts:      1 passed, 1 total
# Test Suites: 13 passed, 13 total
# Tests:       254 passed, 254 total
```
