### PR TITLE
fix(libkapi): raise Kine gRPC keepalive MinTime to stop GOAWAY(ENHANCE_YOUR_CALM)

### DIFF
--- a/pkg/libkapi/storage/kine.go
+++ b/pkg/libkapi/storage/kine.go
@@ -12,6 +12,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/k3s-io/kine/pkg/endpoint"
 )
@@ -40,6 +41,31 @@ const (
 	kinePollBatchSize         = 500
 )
 
+// gRPC keepalive tuning for Kine's embedded server. Left unset, endpoint.Listen
+// builds its own grpc.Server using etcd's embed.DefaultGRPCKeepAliveMinTime
+// (5s) as the KeepaliveEnforcementPolicy.MinTime - the minimum interval the
+// server tolerates between PING frames from a client before it strikes it as
+// abusive and, after a few strikes, sends GOAWAY(ENHANCE_YOUR_CALM,
+// "too_many_pings").
+//
+// That 5s default is sized for a multi-tenant etcd server fielding pings from
+// many independent, potentially untrusted clients. Here, the only clients are
+// this same process's own etcd3 clients (one per API group, all dialing the
+// same local unix socket), and the pings in question are grpc-go's automatic
+// BDP (bandwidth-delay-product) pings - not user-configured keepalives -
+// which each connection's transport sends on its own schedule as it receives
+// stream data (e.g. watch events). With several such connections active
+// during storage initialization, the 5s window is tight enough to trip on
+// legitimate traffic: real signal in a multi-tenant deployment, false-positive
+// churn here. Raising MinTime well above any plausible per-connection BDP
+// ping cadence keeps the enforcement policy meaningful without punishing
+// Kine's only, trusted callers.
+const (
+	kineGRPCKeepaliveMinTime = 30 * time.Second
+	kineGRPCKeepaliveTime    = 2 * time.Hour
+	kineGRPCKeepaliveTimeout = 20 * time.Second
+)
+
 // Readiness probe constants. endpoint.Listen returns the unix-socket
 // endpoint as soon as Kine is configured, but its gRPC server goroutine
 // may not yet be accept()-ing connections. waitForKineReady bridges that
@@ -62,6 +88,23 @@ const (
 	// gRPC server is accepting connections and the backend is wired.
 	kineHealthCheckKey = "health-check"
 )
+
+// newKineGRPCServer builds the gRPC server startKine hands to Kine via
+// Config.GRPCServer, in place of the one endpoint.Listen would otherwise
+// build internally with etcd's own keepalive defaults. See the
+// kineGRPCKeepalive* constants for why MinTime is raised.
+func newKineGRPCServer() *grpc.Server {
+	return grpc.NewServer(
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             kineGRPCKeepaliveMinTime,
+			PermitWithoutStream: false,
+		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    kineGRPCKeepaliveTime,
+			Timeout: kineGRPCKeepaliveTimeout,
+		}),
+	)
+}
 
 // startKine spawns an in-process Kine endpoint that speaks the etcd3 client
 // protocol on a private, per-instance unix socket, translating it into SQL
@@ -111,6 +154,7 @@ func startKine(ctx context.Context,
 	listenAddr := "unix://" + filepath.Join(tmpDir, kineSocketFileName)
 
 	etcdConfig, err := endpointListen(ctx, endpoint.Config{
+		GRPCServer:            newKineGRPCServer(),
 		Listener:              listenAddr,
 		Endpoint:              dbEndpoint,
 		WaitGroup:             kineWaitGroup,

--- a/pkg/libkapi/storage/kine_internal_test.go
+++ b/pkg/libkapi/storage/kine_internal_test.go
@@ -43,3 +43,33 @@ func TestStartKineRecoversFromListenPanic(t *testing.T) {
 	assert.Nil(t, endpoints)
 	assert.Nil(t, cleanup)
 }
+
+// TestStartKinePassesTunedGRPCServer asserts that startKine hands
+// endpoint.Listen a pre-built Config.GRPCServer rather than leaving it unset
+// - see the kineGRPCKeepalive* constants for why a tuned server is required
+// to avoid GOAWAY(ENHANCE_YOUR_CALM, "too_many_pings") on Kine's default
+// keepalive enforcement policy.
+//
+//nolint:paralleltest // mutates the package-level endpointListen seam, see
+// TestStartKineRecoversFromListenPanic above.
+func TestStartKinePassesTunedGRPCServer(t *testing.T) {
+	original := endpointListen
+
+	t.Cleanup(func() { endpointListen = original })
+
+	var gotConfig endpoint.Config
+
+	endpointListen = func(_ context.Context, config endpoint.Config) (endpoint.ETCDConfig, error) {
+		gotConfig = config
+
+		return endpoint.ETCDConfig{Endpoints: []string{"unix://test.sock"}}, nil
+	}
+
+	var kineWaitGroup sync.WaitGroup
+
+	_, cleanup, err := startKine(context.Background(), "postgres://example", &kineWaitGroup)
+	t.Cleanup(cleanup)
+
+	require.NoError(t, err)
+	require.NotNil(t, gotConfig.GRPCServer)
+}


### PR DESCRIPTION
## Summary

Fixes #458.

`startKine` (`pkg/libkapi/storage/kine.go`) now builds and passes its own `*grpc.Server` via `endpoint.Config.GRPCServer`, with `KeepaliveEnforcementPolicy.MinTime` raised from etcd's `embed.DefaultGRPCKeepAliveMinTime` (5s) to 30s.

**Why:** Kine's default gRPC server uses etcd's 5s `MinTime`, sized for a multi-tenant etcd server fielding pings from many independent, potentially untrusted clients. The embedded apiserver opens one etcd3 `clientv3.Client` per API group, all dialing the same local Kine unix socket. Each connection's grpc-go transport sends automatic BDP (bandwidth-delay-product) pings on its own schedule as it receives stream data (e.g. watch events) — these aren't user-configured keepalives and aren't tunable via `storagebackend.Config`. During storage initialization, this ping traffic trips the 5s enforcement window on legitimate, trusted (same-process, local-socket-only) connections, and Kine's server sends `GOAWAY(ENHANCE_YOUR_CALM, "too_many_pings")`, logged at ERROR by `libkapi/logging.InstallGRPCLogAdapter` and causing repeated connection churn (self-healing via reconnect, but noisy).

This is candidate fix (4) from the issue — the lowest-blast-radius, fully self-contained mitigation available at the `libkapi` layer. Candidates (1) and (2) (sharing/pooling etcd3 client connections, or disabling client-side BDP estimation) would require changes to `k8s.io/apiserver`'s storage factory or its etcd3 client construction, which `storagebackend.Config` does not expose today.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass, including new `TestStartKinePassesTunedGRPCServer` asserting `startKine` wires a non-nil `Config.GRPCServer`
- [x] `make build` — builds successfully
- [x] `make build-image` — Docker image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)