### PR TITLE
fix(azure): add Talos API NSG rule for public mode controlplane subnet

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.28.1
+version: 0.28.2
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
@@ -137,6 +137,25 @@ spec:
           - {{ $cpSubnetCIDR }}
         securityGroup:
           name: {{ printf "%s-controlplane-nsg" .Release.Name }}
+          {{- /*
+            Allow Talos API (TCP/50000) from within the VNet so that control
+            plane nodes can communicate peer-to-peer.  The autobootstrap
+            extension scans peers on this port to elect a leader and reach
+            quorum.  CAPZ merges these securityRules with the rules it
+            auto-generates (e.g. the 6443 allow-from-LB rule) and does NOT
+            remove rules it didn't create.
+          */}}
+          securityRules:
+            - name: allow-talos-api-from-vnet
+              description: "Allow Talos API (port 50000) from within the VNet"
+              protocol: Tcp
+              direction: Inbound
+              priority: 200
+              source: VirtualNetwork
+              sourcePorts: "*"
+              destination: "*"
+              destinationPorts: "50000"
+              action: Allow
       - name: {{ printf "%s-node-subnet" .Release.Name }}
         role: node
         cidrBlocks:
@@ -169,11 +188,12 @@ spec:
         securityGroup:
           name: {{ printf "%s-controlplane-nsg" .Release.Name }}
           {{- /*
-            Add an explicit inbound rule for Talos API (TCP/50000) from within
-            the VNet so that talosctl can reach the internal apiServerLB's
-            additional LB rule.  CAPZ merges these securityRules with the
-            rules it auto-generates (e.g. the 6443 allow-from-LB rule) and
-            does NOT remove rules it didn't create.
+            Allow Talos API (TCP/50000) from within the VNet so that control
+            plane nodes can communicate peer-to-peer.  The autobootstrap
+            extension scans peers on this port to elect a leader and reach
+            quorum.  CAPZ merges these securityRules with the rules it
+            auto-generates (e.g. the 6443 allow-from-LB rule) and does NOT
+            remove rules it didn't create.
           */}}
           securityRules:
             - name: allow-talos-api-from-vnet

--- a/charts/kommodity-cluster/tests/azure_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_cluster_test.yaml
@@ -173,6 +173,12 @@ tests:
           path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].destinationPorts
           value: "50000"
       - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].action
+          value: Allow
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].priority
+          value: 200
+      - equal:
           path: spec.networkSpec.subnets[0].natGateway.name
           value: test-cluster-node-natgw-1
       - equal:
@@ -231,6 +237,30 @@ tests:
       - equal:
           path: spec.networkSpec.subnets[0].role
           value: control-plane
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.name
+          value: test-cluster-controlplane-nsg
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].name
+          value: allow-talos-api-from-vnet
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].protocol
+          value: Tcp
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].direction
+          value: Inbound
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].source
+          value: VirtualNetwork
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].destinationPorts
+          value: "50000"
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].action
+          value: Allow
+      - equal:
+          path: spec.networkSpec.subnets[0].securityGroup.securityRules[0].priority
+          value: 200
       - equal:
           path: spec.networkSpec.subnets[1].name
           value: test-cluster-node-subnet


### PR DESCRIPTION
## Problem

Public-mode Azure clusters were missing the `allow-talos-api-from-vnet` security rule (TCP/50000 from `VirtualNetwork`) on the controlplane subnet NSG. This rule exists in private mode but was absent from the public mode template.

Without it, the autobootstrap extension cannot scan peers on port 50000, so public clusters with autobootstrap enabled never reach quorum and fail to bootstrap.

## Root Cause

The chart has two code paths for Azure NSG creation:

1. **CAPZ-managed NSG** (`cluster.yaml`) — inline `securityRules` on the `AzureCluster` networkSpec. Private mode had the rule; public mode did not.
2. **BYO-VNet ASO CRs** (`networkresources.yaml`) — already emitted the rule for **both** public and private modes.

Only path 1 was broken — specifically the public branch (`$isPublic` block at line 132), which emitted the controlplane subnet with a named NSG but no `securityRules`.

## Fix

- Added the `allow-talos-api-from-vnet` security rule to the public-mode controlplane subnet in `cluster.yaml`, identical to the private-mode rule.
- Fixed the misleading private-mode comment that referenced a nonexistent "additional LB rule" — now accurately describes peer-to-peer autobootstrap scanning.
- Added `securityRules[0]` assertions to the public-mode test case.
- Bumped chart version 0.27.1 → 0.27.2.

## Testing

All 246 helm unit tests pass:

```
Charts:      1 passed, 1 total
Test Suites: 13 passed, 13 total
Tests:       246 passed, 246 total
```
