### PR TITLE
fix(azure-deployment): add time_sleep after container app environment creation

### DIFF
--- a/terraform/modules/kommodity_azure_deployment/README.md
+++ b/terraform/modules/kommodity_azure_deployment/README.md
@@ -61,6 +61,7 @@ The `azurerm.dns` provider alias is required because the DNS zone typically live
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.69.0 |
 | <a name="provider_azurerm.dns"></a> [azurerm.dns](#provider\_azurerm.dns) | 4.69.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.14.1 |
 
 ## Modules
 
@@ -92,6 +93,7 @@ No modules.
 | [azurerm_subnet.kommodity-db-sn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network.kommodity-vn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [random_password.database-password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [time_sleep.wait_for_environment](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone) | data source |
 
 ## Inputs

--- a/terraform/modules/kommodity_azure_deployment/main.tf
+++ b/terraform/modules/kommodity_azure_deployment/main.tf
@@ -184,6 +184,13 @@ resource "azurerm_container_app_environment" "kommodity-environment" {
   }
 }
 
+resource "time_sleep" "wait_for_environment" {
+  create_duration = "60s"
+  triggers = {
+    environment_id = azurerm_container_app_environment.kommodity-environment.id
+  }
+}
+
 resource "azurerm_monitor_diagnostic_setting" "kommodity-environment" {
   name                           = "${var.resource_group.name}-environment-logs"
   target_resource_id             = azurerm_container_app_environment.kommodity-environment.id
@@ -214,6 +221,7 @@ resource "azurerm_container_app" "kommodity-app" {
     azurerm_resource_group.kommodity-resource-group,
     azurerm_container_app_environment.kommodity-environment,
     azurerm_postgresql_flexible_server_database.this,
+    time_sleep.wait_for_environment,
   ]
   name                         = "${var.resource_group.name}-app"
   container_app_environment_id = azurerm_container_app_environment.kommodity-environment.id
@@ -409,7 +417,7 @@ resource "azurerm_container_app_environment_managed_certificate" "this" {
   subject_name                 = trimsuffix(azurerm_dns_cname_record.kommodity.fqdn, ".")
   domain_control_validation    = "CNAME"
 
-  depends_on = [azurerm_container_app_custom_domain.this]
+  depends_on = [azurerm_container_app_custom_domain.this, time_sleep.wait_for_environment]
 }
 
 resource "azapi_update_resource" "bind_cert" {


### PR DESCRIPTION
## Problem

`azurerm_container_app_environment` returns "created" to the azurerm provider before Azure's async provisioning reaches `Succeeded`. The subsequent `azurerm_container_app` resource — which depends on the environment — fails with:

```
ManagedEnvironmentNotProvisioned
```

## Fix

Add a `time_sleep` resource (60s) after the container app environment, and add it to `depends_on` of:
- `azurerm_container_app.kommodity-app`
- `azurerm_container_app_environment_managed_certificate.this`

The `time` provider was already declared in `providers.tf` (`hashicorp/time ~> 0.14`) but never used — no new provider needed.

## What was NOT changed

- `providers.tf` — time provider already declared
- No new variables — 60s is a fixed constant, not a configurable value
- `azurerm_monitor_diagnostic_setting.kommodity-environment` — reads the environment ID but doesn't depend on full provisioning

## Validation

- [x] `terraform fmt` — clean
- [x] `terraform test` — 1 passed, 0 failed
- [ ] Manual: create a new environment from scratch and confirm no `ManagedEnvironmentNotProvisioned` error
