### PR TITLE
fix(ci): compare generated files against working tree in consistency checks

### DIFF
--- a/.github/workflows/fetch-providers-check.yml
+++ b/.github/workflows/fetch-providers-check.yml
@@ -31,15 +31,13 @@ jobs:
 
       - name: Check for changes in providers.yaml
         id: diff
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           crds_changed=false
           webhooks_changed=false
-          if ! git diff --exit-code origin/$BRANCH_NAME -- pkg/provider/crds/*.yaml; then
+          if ! git diff --exit-code -- pkg/provider/crds/*.yaml; then
             crds_changed=true
           fi
-          if ! git diff --exit-code origin/$BRANCH_NAME -- pkg/provider/webhooks/*.yaml; then
+          if ! git diff --exit-code -- pkg/provider/webhooks/*.yaml; then
             webhooks_changed=true
           fi
 

--- a/.github/workflows/fetch-providers-check.yml
+++ b/.github/workflows/fetch-providers-check.yml
@@ -34,10 +34,18 @@ jobs:
         run: |
           crds_changed=false
           webhooks_changed=false
+          # Tracked-file modifications.
           if ! git diff --exit-code -- pkg/provider/crds/*.yaml; then
             crds_changed=true
           fi
           if ! git diff --exit-code -- pkg/provider/webhooks/*.yaml; then
+            webhooks_changed=true
+          fi
+          # Newly generated (untracked) files slip past git diff.
+          if [ -n "$(git ls-files --others --exclude-standard -- pkg/provider/crds/*.yaml)" ]; then
+            crds_changed=true
+          fi
+          if [ -n "$(git ls-files --others --exclude-standard -- pkg/provider/webhooks/*.yaml)" ]; then
             webhooks_changed=true
           fi
 
@@ -50,5 +58,5 @@ jobs:
       - name: Fail if providers.yaml changed
         if: ${{ steps.diff.outputs.diff_found == 'true' }}
         run: |
-          echo "Error: One or more files in pkg/provider/crds/*.yaml or pkg/provider/webhooks/*.yaml have changed after running 'make fetch-providers'. Please commit the updated files."
+          echo "Error: One or more files in pkg/provider/crds/*.yaml or pkg/provider/webhooks/*.yaml have changed or been added after running 'make fetch-providers'. Please commit the updated files."
           exit 1

--- a/.github/workflows/fetch-providers-check.yml
+++ b/.github/workflows/fetch-providers-check.yml
@@ -7,7 +7,7 @@ on:
       - "Makefile"
       - "pkg/provider/providers.yaml"
       - "pkg/provider/crds.yaml"
-      - ".github/workflows/fetch-providers-check.yaml"
+      - ".github/workflows/fetch-providers-check.yml"
       - "go.mod"
       - "go.sum"
 

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -35,11 +35,9 @@ jobs:
 
       - name: Check for changes in openapi folder
         id: diff
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           openapi_changed=false
-          if ! git diff --exit-code origin/$BRANCH_NAME -- "openapi/**/*"; then
+          if ! git diff --exit-code -- "openapi/**/*"; then
             openapi_changed=true
           fi
 

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -37,7 +37,12 @@ jobs:
         id: diff
         run: |
           openapi_changed=false
+          # Tracked-file modifications.
           if ! git diff --exit-code -- "openapi/**/*"; then
+            openapi_changed=true
+          fi
+          # Newly generated (untracked) files slip past git diff.
+          if [ -n "$(git ls-files --others --exclude-standard -- "openapi/**/*")" ]; then
             openapi_changed=true
           fi
 
@@ -50,7 +55,7 @@ jobs:
       - name: Fail if openapi spec has changed
         if: ${{ steps.diff.outputs.diff_found == 'true' }}
         run: |
-          echo "Error: One or more files in openapi/**/* have changed after running 'make generate'. Please commit the updated files."
+          echo "Error: One or more files in openapi/**/* have changed or been added after running 'make generate'. Please commit the updated files."
           exit 1
 
   openapi-spec-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Detect semantic release
         uses: docker://ghcr.io/codfish/semantic-release-action@sha256:5d5447090feb2f9252aac2825ef14e244ecf53528fbe87d585b459adb547b914 # v4
@@ -123,8 +122,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -185,8 +183,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -218,8 +215,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -270,8 +266,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
The fetch-providers and openapi consistency checks diffed against
origin/$BRANCH_NAME, which only resolves for same-repo PRs. Fork PR
head refs live in the fork, not upstream origin, so the diff failed
(exit 128) and the negation wrongly reported generated drift.

Compare the working tree directly instead: after running the
generation target, git diff --exit-code against the checked-out PR
head detects any uncommitted regeneration drift, fork or not.

Signed-off-by: Paul Thuriot <pth@corti.ai>
