### PR TITLE
fix(ci): pin Go to go.mod version instead of stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Detect semantic release
         uses: docker://ghcr.io/codfish/semantic-release-action@sha256:5d5447090feb2f9252aac2825ef14e244ecf53528fbe87d585b459adb547b914 # v4
@@ -123,8 +122,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -185,8 +183,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -218,8 +215,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -270,8 +266,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
The release workflow used go-version: stable, resolving to Go 1.27.
The k8s.io/apiserver v0.32.6 + otelhttp graph is inconsistent under
Go 1.27 (otelhttp.WithPublicEndpoint undefined), breaking build,
lint, and coverage. Pin to go.mod (go 1.26.1) until deps are bumped.

Signed-off-by: Paul Thuriot <pth@corti.ai>
