### PR TITLE
fix(byot): embed config hash in machine name for version rolls [PLA-6511]

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.0
+version: 0.29.1
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.1
+version: 0.29.2
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -191,6 +191,27 @@ Any values that should trigger a new Talos config template when changed should b
 {{- with (dig "instanceVolumes" "" .poolValues) -}}
 	{{- $_ := set $data "instanceVolumes" . -}}
 {{- end -}}
+{{- /*
+	Byot fuses Machine + bootstrap + infra into one static object per publicIP,
+	so a version/spec bump must roll a new Machine (new name) to force cabpt to
+	regenerate the bootstrap secret (cabpt ignores an already-Ready TalosConfig).
+	Only inputs that actually change the rendered Talos machine config are hashed:
+	kubernetes.version (drives the kubelet image), generateType (init vs controlplane
+	vs worker), and per-machine strategicPatches. Gated on Byot so non-Byot hashes
+	stay byte-identical and do not trigger spurious rolls.
+*/ -}}
+{{- if eq .allValues.kommodity.provider.name "Byot" -}}
+	{{- $k8sVersion := default .allValues.kubernetes.version (dig "kubernetes" "version" "" .poolValues) -}}
+	{{- $_ := set $data "kubernetesVersion" $k8sVersion -}}
+	{{- with .generateType -}}
+		{{- $_ := set $data "generateType" . -}}
+	{{- end -}}
+	{{- with .machineValues -}}
+		{{- if .strategicPatches -}}
+			{{- $_ := set $data "machineStrategicPatches" .strategicPatches -}}
+		{{- end -}}
+	{{- end -}}
+{{- end -}}
 {{- toJson $data | sha256sum | trunc 6 -}}
 {{- end -}}
 

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -195,10 +195,12 @@ Any values that should trigger a new Talos config template when changed should b
 	Byot fuses Machine + bootstrap + infra into one static object per publicIP,
 	so a version/spec bump must roll a new Machine (new name) to force cabpt to
 	regenerate the bootstrap secret (cabpt ignores an already-Ready TalosConfig).
-	Only inputs that actually change the rendered Talos machine config are hashed:
-	kubernetes.version (drives the kubelet image), generateType (init vs controlplane
-	vs worker), and per-machine strategicPatches. Gated on Byot so non-Byot hashes
-	stay byte-identical and do not trigger spurious rolls.
+	Only inputs that should trigger a roll are hashed: kubernetes.version (drives
+	the kubelet image), generateType (init vs controlplane vs worker), the
+	per-machine publicIP (immutable on ByotMachine, so a change must roll a new
+	name rather than fail an in-place patch), and per-machine strategicPatches.
+	Gated on Byot so non-Byot hashes stay byte-identical and do not trigger
+	spurious rolls.
 */ -}}
 {{- if eq .allValues.kommodity.provider.name "Byot" -}}
 	{{- $k8sVersion := default .allValues.kubernetes.version (dig "kubernetes" "version" "" .poolValues) -}}
@@ -207,6 +209,9 @@ Any values that should trigger a new Talos config template when changed should b
 		{{- $_ := set $data "generateType" . -}}
 	{{- end -}}
 	{{- with .machineValues -}}
+		{{- with .publicIP -}}
+			{{- $_ := set $data "publicIP" . -}}
+		{{- end -}}
 		{{- if .strategicPatches -}}
 			{{- $_ := set $data "machineStrategicPatches" .strategicPatches -}}
 		{{- end -}}

--- a/charts/kommodity-cluster/templates/provider/byot/machines.yaml
+++ b/charts/kommodity-cluster/templates/provider/byot/machines.yaml
@@ -31,7 +31,7 @@
 {{- if not $m.publicIP }}
 {{- fail (printf "kommodity.controlplane.staticMachines.%s requires publicIP" $name) -}}
 {{- end }}
-{{- $machineName := printf "%s-cp-%s" $.Release.Name $name }}
+{{- $machineName := printf "%s-cp-%s-%s" $.Release.Name $name (include "kommodity-cluster.talosConfigHash" (dict "poolValues" $cp "allValues" $.Values "generateType" (ternary "init" "controlplane" $m.init) "machineValues" $m)) }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: TalosConfig
@@ -98,8 +98,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   publicIP: {{ $m.publicIP | quote }}
   {{- if $m.failureDomain }}
@@ -120,8 +118,6 @@ metadata:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
     cluster.x-k8s.io/control-plane: ""
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   clusterName: {{ $.Release.Name }}
   {{- if $m.failureDomain }}
@@ -151,7 +147,7 @@ spec:
 {{- if not $m.publicIP }}
 {{- fail (printf "kommodity.nodepools.%s.staticMachines.%s requires publicIP" $poolName $name) -}}
 {{- end }}
-{{- $machineName := printf "%s-worker-%s-%s" $.Release.Name $poolName $name }}
+{{- $machineName := printf "%s-worker-%s-%s-%s" $.Release.Name $poolName $name (include "kommodity-cluster.talosConfigHash" (dict "poolValues" $np "allValues" $.Values "generateType" "worker" "machineValues" $m)) }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: TalosConfig
@@ -212,8 +208,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   publicIP: {{ $m.publicIP | quote }}
   {{- if $m.failureDomain }}
@@ -234,8 +228,6 @@ metadata:
     app.kubernetes.io/managed-by: kommodity
     cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
     kommodity.io/nodepool: {{ $poolName }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   clusterName: {{ $.Release.Name }}
   {{- if $m.failureDomain }}

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -69,9 +69,9 @@ tests:
       path: spec.generateType
       value: init
     asserts:
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: test-cluster-cp-cp-0
+          pattern: ^test-cluster-cp-cp-0-[a-f0-9]{6}$
 
   - it: should mark the worker static machine TalosConfig as worker
     template: templates/provider/byot/machines.yaml
@@ -79,9 +79,9 @@ tests:
       path: spec.generateType
       value: worker
     asserts:
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: test-cluster-worker-default-worker-0
+          pattern: ^test-cluster-worker-default-worker-0-[a-f0-9]{6}$
 
   - it: should adopt the control plane machine by public IP
     template: templates/provider/byot/machines.yaml
@@ -91,9 +91,9 @@ tests:
     asserts:
       - isKind:
           of: ByotMachine
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: test-cluster-cp-cp-0
+          pattern: ^test-cluster-cp-cp-0-[a-f0-9]{6}$
 
   - it: should label the control plane Machine as control-plane
     template: templates/provider/byot/machines.yaml
@@ -103,9 +103,9 @@ tests:
     asserts:
       - isKind:
           of: Machine
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: test-cluster-cp-cp-0
+          pattern: ^test-cluster-cp-cp-0-[a-f0-9]{6}$
 
   - it: should not create a TalosControlPlane for Byot
     template: templates/talos/controlplane.yaml
@@ -317,6 +317,54 @@ tests:
     asserts:
       - isKind:
           of: Machine
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: test-cluster-worker-default-worker-0
+          pattern: ^test-cluster-worker-default-worker-0-[a-f0-9]{6}$
+
+  - it: should bind the Machine bootstrap and infra refs to the hashed name
+    template: templates/provider/byot/machines.yaml
+    documentSelector:
+      path: kind
+      value: Machine
+      matchMany: true
+    asserts:
+      - matchRegex:
+          path: spec.bootstrap.configRef.name
+          pattern: ^test-cluster-(cp-cp-0|worker-default-worker-0)-[a-f0-9]{6}$
+      - matchRegex:
+          path: spec.infrastructureRef.name
+          pattern: ^test-cluster-(cp-cp-0|worker-default-worker-0)-[a-f0-9]{6}$
+
+  - it: should not keep ByotMachine or Machine across helm uninstall (no resource-policy)
+    template: templates/provider/byot/machines.yaml
+    documentSelector:
+      path: kind
+      value: ByotMachine
+      matchMany: true
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: should roll the control-plane machine name when kubernetes.version bumps
+    template: templates/provider/byot/machines.yaml
+    set:
+      kubernetes.version: v1.33.4
+    documentSelector:
+      path: spec.generateType
+      value: init
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-cluster-cp-cp-0-c48133$
+
+  - it: should roll the control-plane machine name to a different hash on a different kubernetes.version
+    template: templates/provider/byot/machines.yaml
+    set:
+      kubernetes.version: v1.33.5
+    documentSelector:
+      path: spec.generateType
+      value: init
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-cluster-cp-cp-0-9215ae$

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -335,11 +335,21 @@ tests:
           path: spec.infrastructureRef.name
           pattern: ^test-cluster-(cp-cp-0|worker-default-worker-0)-[a-f0-9]{6}$
 
-  - it: should not keep ByotMachine or Machine across helm uninstall (no resource-policy)
+  - it: should not keep ByotMachine across helm uninstall (no resource-policy)
     template: templates/provider/byot/machines.yaml
     documentSelector:
       path: kind
       value: ByotMachine
+      matchMany: true
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: should not keep Machine across helm uninstall (no resource-policy)
+    template: templates/provider/byot/machines.yaml
+    documentSelector:
+      path: kind
+      value: Machine
       matchMany: true
     asserts:
       - notExists:
@@ -355,7 +365,7 @@ tests:
     asserts:
       - matchRegex:
           path: metadata.name
-          pattern: ^test-cluster-cp-cp-0-c48133$
+          pattern: ^test-cluster-cp-cp-0-f30879$
 
   - it: should roll the control-plane machine name to a different hash on a different kubernetes.version
     template: templates/provider/byot/machines.yaml
@@ -367,4 +377,16 @@ tests:
     asserts:
       - matchRegex:
           path: metadata.name
-          pattern: ^test-cluster-cp-cp-0-9215ae$
+          pattern: ^test-cluster-cp-cp-0-ab2799$
+
+  - it: should roll the control-plane machine name when a static machine publicIP changes
+    template: templates/provider/byot/machines.yaml
+    set:
+      kommodity.controlplane.staticMachines.cp-0.publicIP: 203.0.113.99
+    documentSelector:
+      path: spec.generateType
+      value: init
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-cluster-cp-cp-0-170993$

--- a/charts/kommodity-cluster/values.byot.yaml
+++ b/charts/kommodity-cluster/values.byot.yaml
@@ -24,6 +24,18 @@ kommodity:
         - type: Ready
           status: "False"
           timeout: 300s
+    # Rolling-replacement upgrades: a kubernetes.version / talos.version /
+    # strategicPatches bump changes the config hash embedded in each Machine +
+    # ByotMachine + TalosConfig name, so helm creates new objects and deletes the
+    # old ones. The old ByotMachine's splitPolicy governs the delete:
+    #   splitPolicy: Reset (default) wipes the VM (STATE+EPHEMERAL reset) before
+    #     release -> the new Machine re-bootstraps from maintenance mode.
+    #   splitPolicy: None  leaves the VM's config+datastore intact -> the new
+    #     ByotMachine re-adopts the same VM, re-applies the new Talos config, and
+    #     the kubelet restarts at the new version (faster, no etcd member loss).
+    # For k8s version upgrades set splitPolicy: None on every static machine
+    # (and on the controlplane/nodepool block as a default) BEFORE bumping the
+    # version, otherwise each rolled machine is wiped and re-bootstrapped.
     # Optional lifecycle policy defaults for control plane static machines
     # Static machine entries take precedence
     #   joinPolicy: Reset  # wipe each machine before adopting it (defaults to None)
@@ -69,6 +81,9 @@ kommodity:
           - type: Ready
             status: "False"
             timeout: 300s
+      # For k8s version upgrades set splitPolicy: None (here or per static machine)
+      # BEFORE bumping the version, otherwise each rolled worker is wiped and
+      # re-bootstrapped. See the controlplane block for the full rationale.
       staticMachines:
         worker-0:
           publicIP: 203.0.113.20

--- a/pkg/test/byot_test.go
+++ b/pkg/test/byot_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,7 +156,8 @@ func rescueBlockedForeignBundle(
 	helpers.InstallKommodityClusterChartByot(t, env, clusterB, byotNamespace, rescueInfra)
 	defer helpers.UninstallKommodityClusterChart(t, env, clusterB, byotNamespace)
 
-	workerMachine := byotWorkerMachineName(clusterB, rescueInfra.WorkerName)
+	workerMachine := discoverByotMachineName(t, byotNamespace, clusterB,
+		byotWorkerMachineName(clusterB, rescueInfra.WorkerName))
 	reason, _ := helpers.WaitForByotMachineCondition(
 		t, env, byotNamespace, workerMachine,
 		byotJoinPreflightCond, corev1.ConditionFalse, byotConditionTimeout)
@@ -235,15 +237,70 @@ type byotNodes struct {
 }
 
 // byotCPMachineName mirrors the chart's "<release>-cp-<key>" naming for control
-// plane ByotMachines (templates/provider/byot/machines.yaml).
+// plane ByotMachines (templates/provider/byot/machines.yaml). It returns the
+// name PREFIX: the chart appends a config-hash suffix (kommodity-cluster.talosConfigHash)
+// that cannot be reconstructed in Go without duplicating helm logic, so callers
+// resolve the full name with discoverByotMachineName after the chart is installed.
 func byotCPMachineName(releaseName string, key string) string {
 	return releaseName + "-cp-" + key
 }
 
 // byotWorkerMachineName mirrors "<release>-worker-<nodepool>-<key>"; the byot
-// values file always uses the "default" nodepool.
+// values file always uses the "default" nodepool. Returns the name PREFIX; see
+// byotCPMachineName for the hash-suffix caveat.
 func byotWorkerMachineName(releaseName string, key string) string {
 	return releaseName + "-worker-default-" + key
+}
+
+// discoverByotMachineName lists CAPI Machines belonging to clusterName and
+// returns the single one whose name starts with prefix. The chart embeds a
+// config hash in each Machine name, so the test discovers the actual rendered
+// name instead of reconstructing it. It polls because Machine creation can
+// lag the helm install returning.
+func discoverByotMachineName(
+	t *testing.T,
+	namespace string,
+	clusterName string,
+	prefix string,
+) string {
+	t.Helper()
+
+	ctx := context.Background()
+	client, err := dynamic.NewForConfig(env.KommodityCfg)
+	require.NoError(t, err)
+
+	gvr := schema.GroupVersionResource{
+		Group:    machineGroup,
+		Version:  machineVersion,
+		Resource: machineResource,
+	}
+
+	var found string
+
+	require.Eventually(t, func() bool {
+		list, err := client.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "cluster.x-k8s.io/cluster-name=" + clusterName,
+		})
+		if err != nil {
+			return false
+		}
+
+		for _, item := range list.Items {
+			if strings.HasPrefix(item.GetName(), prefix) {
+				if found != "" && found != item.GetName() {
+					require.Failf(t, "ambiguous ByotMachine prefix",
+						"prefix %q matched both %q and %q", prefix, found, item.GetName())
+				}
+
+				found = item.GetName()
+			}
+		}
+
+		return found != ""
+	}, byotConditionTimeout, byotNodePollInterval,
+		"no CAPI Machine with prefix %q found for cluster %q", prefix, clusterName)
+
+	return found
 }
 
 // startFreshByotCluster boots the Talos pair in maintenance mode, installs the
@@ -277,8 +334,10 @@ func startFreshByotCluster(t *testing.T, clusterName string, infra helpers.ByotI
 
 	helpers.InstallKommodityClusterChartByot(t, env, clusterName, byotNamespace, infra)
 
-	cpMachineName := byotCPMachineName(clusterName, infra.ControlPlaneName)
-	workerMachineName := byotWorkerMachineName(clusterName, infra.WorkerName)
+	cpMachineName := discoverByotMachineName(t, byotNamespace, clusterName,
+		byotCPMachineName(clusterName, infra.ControlPlaneName))
+	workerMachineName := discoverByotMachineName(t, byotNamespace, clusterName,
+		byotWorkerMachineName(clusterName, infra.WorkerName))
 
 	waitForKubeconfigSecret(t, clusterName)
 


### PR DESCRIPTION
cabpt ignores an already-Ready TalosConfig, so bumping kubernetes.version
on a static Byot machine only changed the Machine.spec.version visually;
the bootstrap secret was never regenerated and the kubelet stayed on the
old version. Mirror the existing rolling-replacement pattern used by other
providers by appending kommodity-cluster.talosConfigHash to the TalosConfig,
ByotMachine and Machine names (all three already share $machineName), so a
version/talos-version/patch bump rolls a new Machine -> new TalosConfig ->
cabpt regenerates fresh -> byot re-adopts the same VM (joinPolicy=None,
carries cluster PKI) -> applies the new Talos config -> kubelet restarts at
the new version.

The hash inputs are gated on provider.name == Byot so non-Byot hashes stay
byte-identical (no spurious rolls). kubernetes.version, generateType and
per-machine strategicPatches are added to the hash for Byot only.

Drop helm.sh/resource-policy: keep from the Byot ByotMachine and Machine so
helm deletes the old-name objects on a hash change; otherwise two ByotMachines
would claim the same publicIP. TalosConfig keeps no keep annotation (cabpt
owns its secret lifecycle).

splitPolicy stays default Reset; document in values.byot.yaml that operators
should set splitPolicy: None before a k8s version upgrade to avoid wiping
each rolled machine (the in-place re-apply path). Provider-side duplicate
publicIP guard tracked in PLA-6603.

Integration test discovers the hashed machine name from the cluster instead
of reconstructing it (the hash cannot be recomputed in Go without duplicating
helm logic).

Signed-off-by: Paul Thuriot <pth@corti.ai>
