### PR TITLE
feat(kubevirt): add spreadAcrossHosts anti-affinity for VM host spread

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.0
+version: 0.30.1
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -38,19 +38,30 @@ Usage: {{ $zones := include "kommodity-cluster.controlPlaneZones" . | fromJsonAr
 {{- end -}}
 
 {{/*
-kommodity.kubevirt.nodeAffinity — render a `nodeAffinity` YAML block that restricts
-VM scheduling to the given zones via the standard `topology.kubernetes.io/zone` label
-on infra-cluster nodes. Returns empty when the zones list is empty.
+kommodity.kubevirt.affinity — render the inner of an `affinity` block (without the
+wrapping `affinity:` key) for a KubevirtMachineTemplate VM spec. It combines:
+
+  - nodeAffinity (required) pinning virt-launcher pods to the given zones via the
+    standard `topology.kubernetes.io/zone` label on infra-cluster nodes. Omitted
+    when the zones list is empty.
+  - podAntiAffinity (required) spreading virt-launcher pods of the same pool across
+    distinct infra-cluster hosts, using the `kubernetes.io/hostname` topology key and
+    a shared `kommodity.io/nodepool` label that the caller must also set on the VMI
+    template metadata. Hard required: if a pool has more replicas than available hosts,
+    the excess pods stay Pending. Omitted when spreadAcrossHosts is false.
 
 KubeVirt provider context: CAPK ignores Machine.Spec.FailureDomain, so the chart's
 per-zone MachineDeployment fan-out does not by itself pin VMs to zones. Injecting
 this affinity on the KubevirtMachineTemplate's VM spec actually constrains where
 virt-launcher pods land on the infra cluster.
 
-Usage: {{ include "kommodity.kubevirt.nodeAffinity" (list "fr-par-1" "fr-par-2") }}
+Usage: {{ include "kommodity.kubevirt.affinity" (dict "zones" (list "fr-par-1" "fr-par-2") "nodepool" "mycluster-default" "spreadAcrossHosts" true) }}
 */}}
-{{- define "kommodity.kubevirt.nodeAffinity" -}}
-{{- if gt (len .) 0 -}}
+{{- define "kommodity.kubevirt.affinity" -}}
+{{- $zones := .zones | default list -}}
+{{- $nodepool := .nodepool -}}
+{{- $spread := .spreadAcrossHosts | default false -}}
+{{- if $zones }}
 nodeAffinity:
   requiredDuringSchedulingIgnoredDuringExecution:
     nodeSelectorTerms:
@@ -58,10 +69,18 @@ nodeAffinity:
           - key: topology.kubernetes.io/zone
             operator: In
             values:
-              {{- range . }}
+              {{- range $zones }}
               - {{ . | quote }}
               {{- end }}
-{{- end -}}
+{{- end }}
+{{- if and $nodepool $spread }}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          kommodity.io/nodepool: {{ $nodepool | quote }}
+      topologyKey: kubernetes.io/hostname
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -217,6 +236,9 @@ Any values that should trigger a new Machine template when changed should be add
 {{- if eq .allValues.kommodity.provider.name "Kubevirt" -}}
 {{- $effectiveEvictionStrategy := default "LiveMigrateIfPossible" (dig "evictionStrategy" "" (default dict .allValues.kommodity.provider.config)) -}}
 {{- $_ := set $data "evictionStrategy" $effectiveEvictionStrategy -}}
+{{- if (dig "spreadAcrossHosts" false .poolValues) -}}
+{{- $_ := set $data "spreadAcrossHosts" true -}}
+{{- end -}}
 {{- end -}}
 {{- $_ := set $data "publicNetworkEnabled" .allValues.kommodity.network.ipv4.public -}}
 {{- $zones := include "kommodity-cluster.poolZones" .poolValues | fromJsonArray -}}

--- a/charts/kommodity-cluster/templates/provider/kubevirt/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/kubevirt/machinetemplate.yaml
@@ -13,7 +13,9 @@
        cannot fan out per zone here. Instead, when controlplane.zones is set we inject a loose
        nodeAffinity that lets every CP VM land on any of the listed zones. */ -}}
 {{- $cpZones := include "kommodity-cluster.poolZones" .Values.kommodity.controlplane | fromJsonArray }}
-{{- $cpAffinity := include "kommodity.kubevirt.nodeAffinity" $cpZones | trim }}
+{{- $cpSpread := dig "spreadAcrossHosts" false .Values.kommodity.controlplane }}
+{{- $cpPoolLabel := printf "%s-controlplane" .Release.Name }}
+{{- $cpAffinity := include "kommodity.kubevirt.affinity" (dict "zones" $cpZones "nodepool" $cpPoolLabel "spreadAcrossHosts" $cpSpread) | trim }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
@@ -56,6 +58,11 @@ spec:
           {{- end }}
           runStrategy: Always
           template:
+            {{- if $cpSpread }}
+            metadata:
+              labels:
+                kommodity.io/nodepool: {{ $cpPoolLabel | quote }}
+            {{- end }}
             spec:
               {{- if $cpAffinity }}
               affinity:
@@ -104,6 +111,8 @@ spec:
        its own template with nodeAffinity pinning the VM to that single zone, matching the
        MachineDeployment-per-zone model. With no zones set, emit one template (unsuffixed). */ -}}
 {{- $npZones := include "kommodity-cluster.poolZones" $np | fromJsonArray }}
+{{- $npSpread := dig "spreadAcrossHosts" false $np }}
+{{- $npPoolLabel := printf "%s-%s" $.Release.Name $name }}
 {{- if eq (len $npZones) 0 }}
 {{- $npZones = list "" }}
 {{- end }}
@@ -111,10 +120,12 @@ spec:
 {{- range $zone := $npZones }}
 {{- $tmplName := printf "%s-worker-%s-%s" $.Release.Name $name $hash }}
 {{- $zoneAffinity := "" }}
+{{- $zoneZones := list }}
 {{- if $zone }}
 {{- $tmplName = printf "%s-worker-%s-%s-%s" $.Release.Name $name $zone $hash }}
-{{- $zoneAffinity = include "kommodity.kubevirt.nodeAffinity" (list $zone) | trim }}
+{{- $zoneZones = list $zone }}
 {{- end }}
+{{- $zoneAffinity = include "kommodity.kubevirt.affinity" (dict "zones" $zoneZones "nodepool" $npPoolLabel "spreadAcrossHosts" $npSpread) | trim }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
@@ -176,6 +187,11 @@ spec:
           {{- end }}
           runStrategy: Always
           template:
+            {{- if $npSpread }}
+            metadata:
+              labels:
+                kommodity.io/nodepool: {{ $npPoolLabel | quote }}
+            {{- end }}
             spec:
               {{- if $zoneAffinity }}
               affinity:

--- a/charts/kommodity-cluster/tests/kubevirt_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/kubevirt_provider_test.yaml
@@ -328,7 +328,7 @@ tests:
           path: spec.template.spec.virtualMachineTemplate.spec.template.spec.dnsConfig.nameservers[0]
           value: 1.1.1.1
         documentIndex: 1
-  - it: should not render affinity when no zones are set
+  - it: should not render affinity when no zones are set and spreadAcrossHosts is unset
     template: templates/provider/kubevirt/machinetemplate.yaml
     asserts:
       - isNull:
@@ -337,12 +337,44 @@ tests:
       - isNull:
           path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity
         documentIndex: 1
-  - it: should inject loose multi-zone nodeAffinity on controlplane when zones are set
+      - isNull:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata
+        documentIndex: 0
+      - isNull:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata
+        documentIndex: 1
+  - it: should render podAntiAffinity (host spread) but no nodeAffinity when spreadAcrossHosts is set without zones
+    template: templates/provider/kubevirt/machinetemplate.yaml
+    set:
+      kommodity.controlplane.spreadAcrossHosts: true
+      kommodity.nodepools.default.spreadAcrossHosts: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.nodeAffinity
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchLabels["kommodity.io/nodepool"]
+          value: test-cluster-controlplane
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["kommodity.io/nodepool"]
+          value: test-cluster-controlplane
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["kommodity.io/nodepool"]
+          value: test-cluster-default
+        documentIndex: 1
+  - it: should inject loose multi-zone nodeAffinity and host-spread podAntiAffinity on controlplane when zones are set
     template: templates/provider/kubevirt/machinetemplate.yaml
     set:
       kommodity.controlplane.zones:
         - zone-a
         - zone-b
+      kommodity.controlplane.spreadAcrossHosts: true
     asserts:
       - equal:
           path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
@@ -360,12 +392,21 @@ tests:
           path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]
           value: zone-b
         documentIndex: 0
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchLabels["kommodity.io/nodepool"]
+          value: test-cluster-controlplane
+        documentIndex: 0
   - it: should fan out one KubevirtMachineTemplate per nodepool zone with single-zone affinity
     template: templates/provider/kubevirt/machinetemplate.yaml
     set:
       kommodity.nodepools.default.zones:
         - zone-a
         - zone-b
+      kommodity.nodepools.default.spreadAcrossHosts: true
     asserts:
       - hasDocuments:
           count: 3
@@ -392,6 +433,22 @@ tests:
       - equal:
           path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
           value: zone-b
+        documentIndex: 2
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["kommodity.io/nodepool"]
+          value: test-cluster-default
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["kommodity.io/nodepool"]
+          value: test-cluster-default
+        documentIndex: 2
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
         documentIndex: 2
   - it: should reference the zone-suffixed KubevirtMachineTemplate from each zone MachineDeployment
     template: templates/provider/capi/machinedeployment.yaml

--- a/charts/kommodity-cluster/values.kubevirt.yaml
+++ b/charts/kommodity-cluster/values.kubevirt.yaml
@@ -79,6 +79,8 @@ kommodity:
     # zones:
     #   - fr-par-1
     #   - fr-par-2
+    # Enforce hard host spread.
+    # spreadAcrossHosts: false
     # Exactly one of 'sku' or 'resources' must be set per pool (mutually exclusive).
     # - sku: references a Kubevirt VirtualMachineClusterInstancetype.
     #   Default set: https://github.com/kubevirt/common-instancetypes#series.
@@ -103,6 +105,8 @@ kommodity:
       # zones:
       #   - zone1
       #   - zone2
+      # Enforce hard host spread.
+      # spreadAcrossHosts: false
       # Exactly one of 'sku' or 'resources' must be set (mutually exclusive).
       sku: d1.xlarge
       # resources:

--- a/charts/kommodity-cluster/values.kubevirt.yaml
+++ b/charts/kommodity-cluster/values.kubevirt.yaml
@@ -80,7 +80,7 @@ kommodity:
     #   - fr-par-1
     #   - fr-par-2
     # Enforce hard host spread.
-    # spreadAcrossHosts: false
+    # spreadAcrossHosts: true
     # Exactly one of 'sku' or 'resources' must be set per pool (mutually exclusive).
     # - sku: references a Kubevirt VirtualMachineClusterInstancetype.
     #   Default set: https://github.com/kubevirt/common-instancetypes#series.
@@ -106,7 +106,7 @@ kommodity:
       #   - zone1
       #   - zone2
       # Enforce hard host spread.
-      # spreadAcrossHosts: false
+      # spreadAcrossHosts: true
       # Exactly one of 'sku' or 'resources' must be set (mutually exclusive).
       sku: d1.xlarge
       # resources:


### PR DESCRIPTION
Add optional hard podAntiAffinity on kubernetes.io/hostname so VMs of the same nodepool (or control plane) land on distinct infra-cluster hosts. Gated behind spreadAcrossHosts (default off) to preserve existing behavior; when enabled, a kommodity.io/nodepool label is added to the VMI template so the scheduler can repel same-pod virt-launcher pods. The flag feeds the machineSpecsHash so toggling triggers a clean rolling rollout. Zone pinning (nodeAffinity) and host spread combine additively when both are set.

Signed-off-by: Paul Thuriot <pth@corti.ai>
