### PR TITLE
fix(ui): correct machine age sort column index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,12 @@ clean: ## Clean the build artifacts.
 	rm -f bin/kommodity
 
 .PHONY: test
-test: ## Run the tests.
+test: test-ui ## Run the tests.
 	go test -cover -v ./...
+
+.PHONY: test-ui
+test-ui: ## Run the UI JavaScript tests.
+	node pkg/ui/sort.test.js
 
 lint: ## Run the linter.
 	$(LINTER) run

--- a/pkg/ui/public/sort.js
+++ b/pkg/ui/public/sort.js
@@ -1,0 +1,47 @@
+// Machine table sort helpers. Pure comparator extracted so the logic can be
+// unit tested without a DOM (see sort.test.js).
+(function () {
+    "use strict";
+
+    // Index of the Age column in machine detail tables. Keep in sync with
+    // cluster_detail.html: Health, Phase, Name, NodeName, Zone,
+    // Kubernetes Version, Age.
+    const ageColumnIndex = 6;
+
+    function creationTimeOf(row) {
+        const cell = row.cells[ageColumnIndex];
+        return cell ? (cell.getAttribute("data-creation-time") || "") : "";
+    }
+
+    // Sort machine rows by creation time.
+    // dir: "desc" = newest first, "asc" = oldest first.
+    // Mutates rows in place like Array.prototype.sort and returns the array.
+    function sortMachinesByCreation(rows, dir) {
+        return rows.sort(function (a, b) {
+            const timeA = creationTimeOf(a);
+            const timeB = creationTimeOf(b);
+            if (dir === "desc") {
+                return timeB.localeCompare(timeA);
+            }
+            return timeA.localeCompare(timeB);
+        });
+    }
+
+    // Indicator glyph for a sort direction.
+    function sortIndicatorFor(dir) {
+        return dir === "desc" ? "↓" : "↑";
+    }
+
+    if (typeof window !== "undefined") {
+        window.sortMachinesByCreation = sortMachinesByCreation;
+        window.sortIndicatorFor = sortIndicatorFor;
+        window.ageColumnIndex = ageColumnIndex;
+    }
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = {
+            sortMachinesByCreation,
+            sortIndicatorFor,
+            ageColumnIndex,
+        };
+    }
+})();

--- a/pkg/ui/sort.test.js
+++ b/pkg/ui/sort.test.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const assert = require("assert");
+const path = require("path");
+const { sortMachinesByCreation, sortIndicatorFor, ageColumnIndex } =
+    require(path.join(__dirname, "public", "sort.js"));
+
+// Build a fake row whose Age cell carries a data-creation-time attribute.
+// Mirrors the real <tr> shape used by cluster_detail.html.
+function makeRow(creationTime) {
+    const cells = [];
+    for (let i = 0; i < ageColumnIndex + 1; i++) {
+        cells.push({
+            attr: {},
+            getAttribute(name) {
+                return this.attr[name] || null;
+            },
+        });
+    }
+    cells[ageColumnIndex].attr["data-creation-time"] = creationTime;
+    return { cells };
+}
+
+function times(rows) {
+    return rows.map(function (r) {
+        return r.cells[ageColumnIndex].attr["data-creation-time"];
+    });
+}
+
+// Given unsorted rows, desc puts newest (largest RFC3339 string) first.
+(function descNewestFirst() {
+    const rows = [
+        makeRow("2024-01-01T00:00:00Z"),
+        makeRow("2024-03-01T00:00:00Z"),
+        makeRow("2024-02-01T00:00:00Z"),
+    ];
+    const sorted = sortMachinesByCreation(rows.slice(), "desc");
+    assert.deepStrictEqual(times(sorted), [
+        "2024-03-01T00:00:00Z",
+        "2024-02-01T00:00:00Z",
+        "2024-01-01T00:00:00Z",
+    ]);
+})();
+
+// Ascending keeps oldest first.
+(function ascOldestFirst() {
+    const rows = [
+        makeRow("2024-03-01T00:00:00Z"),
+        makeRow("2024-01-01T00:00:00Z"),
+        makeRow("2024-02-01T00:00:00Z"),
+    ];
+    const sorted = sortMachinesByCreation(rows.slice(), "asc");
+    assert.deepStrictEqual(times(sorted), [
+        "2024-01-01T00:00:00Z",
+        "2024-02-01T00:00:00Z",
+        "2024-03-01T00:00:00Z",
+    ]);
+})();
+
+// Missing creation time sorts to the end regardless of direction.
+(function missingCreationTimeDegradesGracefully() {
+    const rows = [
+        makeRow("2024-02-01T00:00:00Z"),
+        makeRow(""),
+        makeRow("2024-01-01T00:00:00Z"),
+    ];
+    const desc = sortMachinesByCreation(rows.slice(), "desc");
+    assert.deepStrictEqual(times(desc), [
+        "2024-02-01T00:00:00Z",
+        "2024-01-01T00:00:00Z",
+        "",
+    ]);
+    const asc = sortMachinesByCreation(rows.slice(), "asc");
+    assert.deepStrictEqual(times(asc), [
+        "",
+        "2024-01-01T00:00:00Z",
+        "2024-02-01T00:00:00Z",
+    ]);
+})();
+
+// Indicator glyphs match direction.
+assert.strictEqual(sortIndicatorFor("desc"), "↓");
+assert.strictEqual(sortIndicatorFor("asc"), "↑");
+
+console.log("pkg/ui/sort.test.js: all tests passed");

--- a/pkg/ui/templates/cluster_detail.html
+++ b/pkg/ui/templates/cluster_detail.html
@@ -315,6 +315,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 // Sort machine rows by creation time
+// Comparator lives in /ui/public/sort.js (window.sortMachinesByCreation) so it
+// can be unit tested in node without a DOM.
 document.querySelectorAll('.sort-creation-time').forEach(function(btn) {
     let sortState = 'asc';
 
@@ -324,23 +326,9 @@ document.querySelectorAll('.sort-creation-time').forEach(function(btn) {
         const rows = Array.from(tbody.querySelectorAll('tr'));
         const indicator = btn.querySelector('.sort-indicator');
 
-        if (sortState === 'asc') {
-            sortState = 'desc';
-            indicator.textContent = '↓';
-            rows.sort(function(a, b) {
-                const timeA = a.cells[5].getAttribute('data-creation-time') || '';
-                const timeB = b.cells[5].getAttribute('data-creation-time') || '';
-                return timeB.localeCompare(timeA);
-            });
-        } else {
-            sortState = 'asc';
-            indicator.textContent = '↑';
-            rows.sort(function(a, b) {
-                const timeA = a.cells[5].getAttribute('data-creation-time') || '';
-                const timeB = b.cells[5].getAttribute('data-creation-time') || '';
-                return timeA.localeCompare(timeB);
-            });
-        }
+        sortState = sortState === 'asc' ? 'desc' : 'asc';
+        window.sortMachinesByCreation(rows, sortState);
+        indicator.textContent = window.sortIndicatorFor(sortState);
 
         rows.forEach(function(row) {
             tbody.appendChild(row);

--- a/pkg/ui/templates/layout.html
+++ b/pkg/ui/templates/layout.html
@@ -14,6 +14,9 @@
 
     <!-- Tailwind CSS (vendored locally for production) -->
     <script src="/ui/public/tailwind.min.js"></script>
+
+    <!-- Machine table sort helpers -->
+    <script src="/ui/public/sort.js"></script>
     <script>
         tailwind.config = {
             darkMode: 'class',


### PR DESCRIPTION
The Age sort handler read cells[5] (Kubernetes Version), which has no data-creation-time attribute, so every row compared equal and the sort was a no-op. Age is column index 6. Extract the comparator into /ui/public/sort.js so it can be unit tested in node without a browser or MCP harness, and wire it into the template and layout.

Signed-off-by: Paul Thuriot <pth@corti.ai>
