### PR TITLE
fix(kubevirt): grant ccm delete verb on nodes

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.1
+version: 0.30.2
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/files/kubevirt-ccm.yaml
+++ b/charts/kommodity-cluster/files/kubevirt-ccm.yaml
@@ -24,6 +24,7 @@ rules:
       - watch
       - update
       - patch
+      - delete
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
The kccm ClusterRole in kubevirt-ccm.yaml omitted the delete verb on nodes, so the cloud-controller-manager node-lifecycle controller cannot remove stale Nodes after the underlying VM is gone. This left orphan NotReady,SchedulingDisabled Nodes in the cluster and produced endless 'unable to delete node ... is forbidden' error loops. Add delete to the nodes rule so the CCM can clean up deleted VMs itself.

Signed-off-by: Paul Thuriot <pth@corti.ai>
