### PR TITLE
fix(api): include profile scope in OIDC kubeconfig when groups claim is configured

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ const (
 	envOIDCClientID                       = "KOMMODITY_OIDC_CLIENT_ID"
 	envOIDCUsernameClaim                  = "KOMMODITY_OIDC_USERNAME_CLAIM"
 	envOIDCGroupsClaim                    = "KOMMODITY_OIDC_GROUPS_CLAIM"
+	envOIDCExtraScopes                    = "KOMMODITY_OIDC_EXTRA_SCOPES"
 	envDatabaseURI                        = "KOMMODITY_DB_URI"
 	envAttestationNonceTTL                = "KOMMODITY_ATTESTATION_NONCE_TTL"
 	envDevelopmentMode                    = "KOMMODITY_DEVELOPMENT_MODE"
@@ -345,6 +346,7 @@ func getOIDCConfig(ctx context.Context) *OIDCConfig {
 	clientID := os.Getenv(envOIDCClientID)
 	usernameClaim := os.Getenv(envOIDCUsernameClaim)
 	groupsClaim := os.Getenv(envOIDCGroupsClaim)
+	extraScopes := parseExtraScopes(os.Getenv(envOIDCExtraScopes))
 
 	if usernameClaim == "" {
 		logger.Info(configurationNotSpecified,
@@ -373,7 +375,41 @@ func getOIDCConfig(ctx context.Context) *OIDCConfig {
 		ClientID:      clientID,
 		UsernameClaim: usernameClaim,
 		GroupsClaim:   groupsClaim,
+		ExtraScopes:   EnsureProfileScope(extraScopes, groupsClaim),
 	}
+}
+
+// parseExtraScopes splits a comma-separated string of OIDC scopes into a slice.
+func parseExtraScopes(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	var scopes []string
+
+	for scope := range strings.SplitSeq(raw, ",") {
+		trimmed := strings.TrimSpace(scope)
+		if trimmed != "" {
+			scopes = append(scopes, trimmed)
+		}
+	}
+
+	return scopes
+}
+
+// EnsureProfileScope adds the "profile" scope if a groups claim is configured
+// and "profile" is not already present. The profile scope is required by Azure
+// AD / Entra ID to include group claims in the ID token.
+func EnsureProfileScope(scopes []string, groupsClaim string) []string {
+	if groupsClaim == "" {
+		return scopes
+	}
+
+	if slices.Contains(scopes, "profile") {
+		return scopes
+	}
+
+	return append(scopes, "profile")
 }
 
 func getAdminGroup() (string, error) {

--- a/pkg/ui/api/kubeconfig.go
+++ b/pkg/ui/api/kubeconfig.go
@@ -243,6 +243,10 @@ func getOIDCConfigFromCluster(
 		oidcConfig.ExtraScopes = trimmedScopes
 	}
 
+	// Ensure the "profile" scope is included when a groups claim is configured,
+	// as it is required by Azure AD / Entra ID to return group claims in the token.
+	oidcConfig.ExtraScopes = config.EnsureProfileScope(oidcConfig.ExtraScopes, oidcConfig.GroupsClaim)
+
 	return oidcConfig, nil
 }
 


### PR DESCRIPTION
## Problem

Azure AD / Entra ID requires the `profile` OIDC scope to include group claims in the ID token. The kubeconfig generator only requested `email` scope, so OIDC-authenticated users had no group membership in their token and could not match group-based `ClusterRoleBindings` — resulting in `Forbidden` errors despite being a member of the correct Azure AD group.

## Fix

Two code paths are updated:

1. **`getOIDCConfig`** (env-var path, Kommodity management kubeconfig): now reads `KOMMODITY_OIDC_EXTRA_SCOPES` env var and uses `EnsureProfileScope` to add `profile` when a groups claim is configured.

2. **`getOIDCConfigFromCluster`** (per-cluster kubeconfig from Talos machine config): calls `EnsureProfileScope` after extracting scopes from the API server extraArgs.

`EnsureProfileScope` adds `profile` to the scopes list if:
- A groups claim is configured (non-empty)
- `profile` is not already in the list