### PR TITLE
fix(chart): move oidc client flags to per-cluster secret

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.2
+version: 0.31.0
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/talos/oidc-client-secret.yaml
+++ b/charts/kommodity-cluster/templates/talos/oidc-client-secret.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Renders the OIDC client-side flags as a Secret in the management cluster.
-The Kommodity UI reads this (by the cluster.x-k8s.io/cluster-name label) when
+The Kommodity UI reads this Secret by name (<clusterName>-oidc-client) when
 serving the OIDC-federated kubeconfig for the downstream cluster, and renders
 these flags verbatim into the `kubectl oidc-login get-token` exec block.
 */ -}}

--- a/charts/kommodity-cluster/templates/talos/oidc-client-secret.yaml
+++ b/charts/kommodity-cluster/templates/talos/oidc-client-secret.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Renders the OIDC client-side flags as a Secret in the management cluster.
+The Kommodity UI reads this (by the cluster.x-k8s.io/cluster-name label) when
+serving the OIDC-federated kubeconfig for the downstream cluster, and renders
+these flags verbatim into the `kubectl oidc-login get-token` exec block.
+*/ -}}
+{{- $oidc := .Values.kommodity.oidc }}
+{{- if and $oidc $oidc.enabled $oidc.clientExtraFlags }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-oidc-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: kommodity
+stringData:
+  # JSON array of literal kubelogin flags, e.g. ["--oidc-extra-scope=email"].
+  clientExtraFlags: {{ $oidc.clientExtraFlags | toJson | quote }}
+{{- end }}

--- a/charts/kommodity-cluster/templates/talos/oidc-helper.yaml
+++ b/charts/kommodity-cluster/templates/talos/oidc-helper.yaml
@@ -1,17 +1,15 @@
 {{- define "kommodity.talos.oidc.extraArgs" -}}
+{{- /*
+Kube-apiserver flags. OIDC client extra flags for `kubectl oidc-login` do NOT belong here; 
+those go in the oidc-client Secret.
+*/ -}}
 {{- $oidc := .oidc -}}
 {{- $args := dict "oidc-issuer-url" $oidc.issuerURL "oidc-client-id" $oidc.clientID -}}
-{{- if $oidc.clientSecret -}}
-{{- $_ := set $args "oidc-client-secret" $oidc.clientSecret -}}
-{{- end -}}
 {{- if $oidc.usernameClaim -}}
 {{- $_ := set $args "oidc-username-claim" $oidc.usernameClaim -}}
 {{- end -}}
 {{- if $oidc.groupsClaim -}}
 {{- $_ := set $args "oidc-groups-claim" $oidc.groupsClaim -}}
-{{- end -}}
-{{- range $scope := $oidc.extraScopes -}}
-{{- $_ := set $args "oidc-extra-scope" $scope -}}
 {{- end -}}
 {{- $args | toJson -}}
 {{- end -}}

--- a/charts/kommodity-cluster/tests/oidc_client_config_test.yaml
+++ b/charts/kommodity-cluster/tests/oidc_client_config_test.yaml
@@ -1,0 +1,71 @@
+suite: test OIDC client Secret served to the UI
+release:
+  name: test-cluster
+  namespace: default
+templates:
+  - templates/talos/oidc-client-secret.yaml
+tests:
+  - it: should not render when oidc is disabled
+    template: templates/talos/oidc-client-secret.yaml
+    set:
+      kommodity.oidc.enabled: false
+      kommodity.oidc.clientExtraFlags:
+        - "--oidc-extra-scope=email"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when clientExtraFlags is empty
+    template: templates/talos/oidc-client-secret.yaml
+    set:
+      kommodity.oidc.enabled: true
+      kommodity.oidc.clientExtraFlags: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when clientExtraFlags is unset
+    template: templates/talos/oidc-client-secret.yaml
+    set:
+      kommodity.oidc.enabled: true
+      kommodity.oidc.clientExtraFlags: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a Secret labelled with the cluster name
+    template: templates/talos/oidc-client-secret.yaml
+    set:
+      kommodity.oidc.enabled: true
+      kommodity.oidc.clientExtraFlags:
+        - "--oidc-extra-scope=email"
+        - "--oidc-extra-scope=groups"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-cluster-oidc-client
+      - equal:
+          path: metadata.namespace
+          value: default
+      - equal:
+          path: metadata.labels
+          value:
+            cluster.x-k8s.io/cluster-name: test-cluster
+            app.kubernetes.io/managed-by: kommodity
+
+  - it: should serialise clientExtraFlags as a JSON array
+    template: templates/talos/oidc-client-secret.yaml
+    set:
+      kommodity.oidc.enabled: true
+      kommodity.oidc.clientExtraFlags:
+        - "--oidc-extra-scope=email"
+        - "--oidc-extra-scope=groups"
+    asserts:
+      - equal:
+          path: stringData.clientExtraFlags
+          value: |-
+            ["--oidc-extra-scope=email","--oidc-extra-scope=groups"]

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -90,24 +90,8 @@ kommodity:
             cpu: 2
             memory: 512Mi
 
-  # OIDC for the workload cluster's kube-apiserver. Set this if you want the
-  # Kommodity UI (running in production / OIDC mode) to render a kubeconfig for
-  # this cluster: the UI serves an OIDC-federated kubeconfig and reads these
-  # settings back off the workload apiserver's extraArgs. Without it the UI shows
-  # "Kubeconfig not available" — the cluster still works; you can always pull the
-  # admin kubeconfig directly from the `<release>-kubeconfig` Secret. Point this at
-  # the SAME identity provider your Kommodity deployment uses. `clientID` and
-  # `issuerURL` are identifiers, not secrets. Changing these args rolls the control
-  # plane on `helm upgrade`.
   oidc:
     enabled: true
-    # Azure AD example: https://login.microsoftonline.com/<TENANT_ID>/v2.0
-    issuerURL: https://login.microsoftonline.com/<YOUR_TENANT_ID>/v2.0
-    clientID: <YOUR_OIDC_CLIENT_ID>
-    usernameClaim: email
-    groupsClaim: groups
-    # clientSecret: <optional — only if your IdP requires it>
-    # extraScopes: []
 
   global:
     strategicPatches:

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -8,16 +8,16 @@ kommodity:
 
   oidc:
     enabled: false
-    # issuerURL: https://login.microsoftonline.com/<YOUR_TENANT_ID>/v2.0 # sets apiserver flag and kubeconfig --oidc-issuer-url flag in UI
-    # clientID: <YOUR_OIDC_CLIENT_ID> # sets apiserver flag and kubeconfig --oidc-client-id flag in UI
-    # usernameClaim: email # sets apiserver flag
-    # groupsClaim: groups # sets apiserver flag
-    # # Extra flags for the OIDC client in the kubeconfig exec block served by the UI.
-    # # These are kubelogin (client) flags, NOT kube-apiserver flags.
-    # clientExtraFlags:
-    #   - "--oidc-extra-scope=email"
-    #   - "--oidc-extra-scope=groups"
-    #   - "--oidc-client-secret=<secret-name>" # optional — only if your IdP requires it
+    issuerURL: <YOUR_ISSUER_URL> # sets apiserver flag and kubeconfig --oidc-issuer-url flag in UI
+    clientID: <YOUR_OIDC_CLIENT_ID> # sets apiserver flag and kubeconfig --oidc-client-id flag in UI
+    usernameClaim: email # sets apiserver flag
+    groupsClaim: groups # sets apiserver flag
+    # Extra flags for the OIDC client in the kubeconfig exec block served by the UI.
+    # These are kubelogin (client) flags, NOT kube-apiserver flags.
+    clientExtraFlags:
+      - "--oidc-extra-scope=email"
+      - "--oidc-extra-scope=groups"
+    #   - "--oidc-client-secret=<secret-name>" # if your IdP requires it
 
   kms:
     enabled: false

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -16,7 +16,6 @@ kommodity:
     # These are kubelogin (client) flags, NOT kube-apiserver flags.
     clientExtraFlags:
       - "--oidc-extra-scope=email"
-      - "--oidc-extra-scope=groups"
 
   kms:
     enabled: false

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -17,7 +17,6 @@ kommodity:
     clientExtraFlags:
       - "--oidc-extra-scope=email"
       - "--oidc-extra-scope=groups"
-    #   - "--oidc-client-secret=<secret-name>" # if your IdP requires it
 
   kms:
     enabled: false

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -8,6 +8,16 @@ kommodity:
 
   oidc:
     enabled: false
+    # issuerURL: https://login.microsoftonline.com/<YOUR_TENANT_ID>/v2.0 # sets apiserver flag and kubeconfig --oidc-issuer-url flag in UI
+    # clientID: <YOUR_OIDC_CLIENT_ID> # sets apiserver flag and kubeconfig --oidc-client-id flag in UI
+    # usernameClaim: email # sets apiserver flag
+    # groupsClaim: groups # sets apiserver flag
+    # # Extra flags for the OIDC client in the kubeconfig exec block served by the UI.
+    # # These are kubelogin (client) flags, NOT kube-apiserver flags.
+    # clientExtraFlags:
+    #   - "--oidc-extra-scope=email"
+    #   - "--oidc-extra-scope=groups"
+    #   - "--oidc-client-secret=<secret-name>" # optional — only if your IdP requires it
 
   kms:
     enabled: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,7 +151,7 @@ type ClientConfig struct {
 // OIDCConfig holds the OIDC configuration settings from the environment variables.
 // For the management cluster's own UI kubeconfig these come from env vars; for a
 // downstream cluster they are assembled by the UI from the cluster's machine
-// config (apiserver validation flags) plus the cluster's OIDC client ConfigMap
+// config (apiserver validation flags) plus the cluster's OIDC client Secret
 // (kubelogin exec-block flags).
 type OIDCConfig struct {
 	IssuerURL         string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,12 +149,16 @@ type ClientConfig struct {
 }
 
 // OIDCConfig holds the OIDC configuration settings from the environment variables.
+// For the management cluster's own UI kubeconfig these come from env vars; for a
+// downstream cluster they are assembled by the UI from the cluster's machine
+// config (apiserver validation flags) plus the cluster's OIDC client ConfigMap
+// (kubelogin exec-block flags).
 type OIDCConfig struct {
-	IssuerURL     string
-	ClientID      string
-	UsernameClaim string
-	GroupsClaim   string
-	ExtraScopes   []string
+	IssuerURL         string
+	ClientID          string
+	UsernameClaim     string
+	GroupsClaim       string
+	ClientExtraFlags  []string
 }
 
 // LoadConfig loads the configuration settings from environment variables and returns a KommodityConfig instance.

--- a/pkg/ui/api/clusterconfig.tmpl
+++ b/pkg/ui/api/clusterconfig.tmpl
@@ -35,13 +35,8 @@ users:
           - get-token
           - --oidc-issuer-url={{ $.OIDCConfig.IssuerURL }}
           - --oidc-client-id={{ $.OIDCConfig.ClientID }}
-          {{- if ne $.OIDCConfig.UsernameClaim "sub" }}
-          - --oidc-extra-scope={{ $.OIDCConfig.UsernameClaim }}
-          {{- end }}
-          {{- if $.OIDCConfig.ExtraScopes }}
-          {{- range $.OIDCConfig.ExtraScopes }}
-          - --oidc-extra-scope={{ . }}
-          {{- end }}
+          {{- range $.OIDCConfig.ClientExtraFlags }}
+          - {{ . }}
           {{- end }}
         interactiveMode: Always
   {{- end }}

--- a/pkg/ui/api/clusterconfig.tmpl
+++ b/pkg/ui/api/clusterconfig.tmpl
@@ -36,7 +36,7 @@ users:
           - --oidc-issuer-url={{ $.OIDCConfig.IssuerURL }}
           - --oidc-client-id={{ $.OIDCConfig.ClientID }}
           {{- range $.OIDCConfig.ClientExtraFlags }}
-          - {{ . }}
+          - {{ . | quote }}
           {{- end }}
         interactiveMode: Always
   {{- end }}

--- a/pkg/ui/api/kommodityconfig.tmpl
+++ b/pkg/ui/api/kommodityconfig.tmpl
@@ -29,7 +29,7 @@ users:
           - --oidc-issuer-url={{ $.OIDCConfig.IssuerURL }}
           - --oidc-client-id={{ $.OIDCConfig.ClientID }}
           {{- range $.OIDCConfig.ClientExtraFlags }}
-          - {{ . }}
+          - {{ . | quote }}
           {{- end }}
         interactiveMode: Always
   {{- else }}

--- a/pkg/ui/api/kommodityconfig.tmpl
+++ b/pkg/ui/api/kommodityconfig.tmpl
@@ -28,13 +28,8 @@ users:
           - get-token
           - --oidc-issuer-url={{ $.OIDCConfig.IssuerURL }}
           - --oidc-client-id={{ $.OIDCConfig.ClientID }}
-          {{- if ne $.OIDCConfig.UsernameClaim "sub" }}
-          - --oidc-extra-scope={{ $.OIDCConfig.UsernameClaim }}
-          {{- end }}
-          {{- if $.OIDCConfig.ExtraScopes }}
-          {{- range $.OIDCConfig.ExtraScopes }}
-          - --oidc-extra-scope={{ . }}
-          {{- end }}
+          {{- range $.OIDCConfig.ClientExtraFlags }}
+          - {{ . }}
           {{- end }}
         interactiveMode: Always
   {{- else }}

--- a/pkg/ui/api/kubeconfig.go
+++ b/pkg/ui/api/kubeconfig.go
@@ -298,8 +298,8 @@ func getFirstMachineConfig(
 	return provider, nil
 }
 
-// oidcClientSecretName is the name of the Secret rendered by the
-// kommodity-cluster chart (templates/talos/oidc-client-config.yaml) carrying the
+// oidcClientSecretName is the suffix of the Secret rendered by the
+// kommodity-cluster chart (templates/talos/oidc-client-secret.yaml) carrying the
 // kubelogin client flags (and possibly a client secret) for the cluster's UI
 // kubeconfig. A Secret rather than a ConfigMap because the flags may carry
 // sensitive material such as --oidc-client-secret.

--- a/pkg/ui/api/kubeconfig.go
+++ b/pkg/ui/api/kubeconfig.go
@@ -232,8 +232,8 @@ func getOIDCConfigFromCluster(
 
 	// Client-side kubelogin flags (e.g. --oidc-extra-scope=...) are not apiserver
 	// flags, so they cannot travel via the machine config. They are rendered by the
-	// chart into a ConfigMap in the management cluster, labelled with the cluster
-	// name, and read here.
+	// chart into a Secret in the management cluster (named "<clusterName>-oidc-client")
+	// and read here.
 	clientExtraFlags, err := getOIDCClientExtraFlags(ctx, clusterName, namespace, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OIDC client extra flags: %w", err)

--- a/pkg/ui/api/kubeconfig.go
+++ b/pkg/ui/api/kubeconfig.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"embed"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
@@ -17,6 +18,7 @@ import (
 	"github.com/kommodity-io/kommodity/pkg/config"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgoclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -228,20 +230,16 @@ func getOIDCConfigFromCluster(
 		oidcConfig.GroupsClaim = groupsClaim
 	}
 
-	// Handle extra scopes - they may be comma-separated or multiple entries
-	if extraScopes, ok := extraArgs["oidc-extra-scope"]; ok {
-		trimmedScopes := make([]string, 0, len(extraScopes))
-		for _, entry := range extraScopes {
-			for scope := range strings.SplitSeq(entry, ",") {
-				trimmed := strings.TrimSpace(scope)
-				if trimmed != "" {
-					trimmedScopes = append(trimmedScopes, trimmed)
-				}
-			}
-		}
-
-		oidcConfig.ExtraScopes = trimmedScopes
+	// Client-side kubelogin flags (e.g. --oidc-extra-scope=...) are not apiserver
+	// flags, so they cannot travel via the machine config. They are rendered by the
+	// chart into a ConfigMap in the management cluster, labelled with the cluster
+	// name, and read here.
+	clientExtraFlags, err := getOIDCClientExtraFlags(ctx, clusterName, namespace, kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OIDC client extra flags: %w", err)
 	}
+
+	oidcConfig.ClientExtraFlags = clientExtraFlags
 
 	return oidcConfig, nil
 }
@@ -298,4 +296,46 @@ func getFirstMachineConfig(
 	}
 
 	return provider, nil
+}
+
+// oidcClientSecretName is the name of the Secret rendered by the
+// kommodity-cluster chart (templates/talos/oidc-client-config.yaml) carrying the
+// kubelogin client flags (and possibly a client secret) for the cluster's UI
+// kubeconfig. A Secret rather than a ConfigMap because the flags may carry
+// sensitive material such as --oidc-client-secret.
+const oidcClientSecretName = "-oidc-client"
+
+// getOIDCClientExtraFlags reads the cluster's OIDC client Secret from the
+// management cluster and returns the literal kubelogin flags it carries. Returns
+// nil (no error) when the Secret is absent — client flags are optional.
+func getOIDCClientExtraFlags(
+	ctx context.Context,
+	clusterName string,
+	namespace string,
+	kubeClient *clientgoclientset.Clientset,
+) ([]string, error) {
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(
+		ctx, clusterName+oidcClientSecretName, metav1.GetOptions{},
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to get OIDC client secret %s/%s: %w",
+			namespace, clusterName+oidcClientSecretName, err)
+	}
+
+	raw, ok := secret.Data["clientExtraFlags"]
+	if !ok || len(strings.TrimSpace(string(raw))) == 0 {
+		return nil, nil
+	}
+
+	var flags []string
+	if err := json.Unmarshal(raw, &flags); err != nil {
+		return nil, fmt.Errorf("failed to parse clientExtraFlags from %s/%s: %w",
+			namespace, secret.Name, err)
+	}
+
+	return flags, nil
 }

--- a/pkg/ui/api/kubeconfig.go
+++ b/pkg/ui/api/kubeconfig.go
@@ -186,8 +186,6 @@ func getKubeConfig(ctx context.Context, clusterName string, kubeClient *clientgo
 
 // getOIDCConfigFromCluster fetches the machine config from the downstream Talos cluster
 // and extracts OIDC configuration from cluster.apiServer.extraArgs.
-//
-//nolint:cyclop
 func getOIDCConfigFromCluster(
 	ctx context.Context,
 	clusterName string,
@@ -298,12 +296,12 @@ func getFirstMachineConfig(
 	return provider, nil
 }
 
-// oidcClientSecretName is the suffix of the Secret rendered by the
+// oidcClientObjectName is the suffix of the Secret rendered by the
 // kommodity-cluster chart (templates/talos/oidc-client-secret.yaml) carrying the
 // kubelogin client flags (and possibly a client secret) for the cluster's UI
 // kubeconfig. A Secret rather than a ConfigMap because the flags may carry
 // sensitive material such as --oidc-client-secret.
-const oidcClientSecretName = "-oidc-client"
+const oidcClientObjectName = "-oidc-client"
 
 // getOIDCClientExtraFlags reads the cluster's OIDC client Secret from the
 // management cluster and returns the literal kubelogin flags it carries. Returns
@@ -315,7 +313,7 @@ func getOIDCClientExtraFlags(
 	kubeClient *clientgoclientset.Clientset,
 ) ([]string, error) {
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(
-		ctx, clusterName+oidcClientSecretName, metav1.GetOptions{},
+		ctx, clusterName+oidcClientObjectName, metav1.GetOptions{},
 	)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -323,7 +321,7 @@ func getOIDCClientExtraFlags(
 		}
 
 		return nil, fmt.Errorf("failed to get OIDC client secret %s/%s: %w",
-			namespace, clusterName+oidcClientSecretName, err)
+			namespace, clusterName+oidcClientObjectName, err)
 	}
 
 	raw, ok := secret.Data["clientExtraFlags"]
@@ -332,7 +330,9 @@ func getOIDCClientExtraFlags(
 	}
 
 	var flags []string
-	if err := json.Unmarshal(raw, &flags); err != nil {
+
+	err = json.Unmarshal(raw, &flags)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse clientExtraFlags from %s/%s: %w",
 			namespace, secret.Name, err)
 	}


### PR DESCRIPTION
## Why

kube-apiserver OIDC flags were piggybacking client-side kubelogin flags
(`--oidc-extra-scope`, `--oidc-client-secret`) through `apiServer.extraArgs`.
`--oidc-extra-scope` is not a valid kube-apiserver flag, so the apiserver
crashed on startup with `unknown flag` → CrashLoopBackOff on every control
plane node → API down, LB empty, cluster unreachable. (Triggered a real
dev-par01 outage; root-caused via a throwaway Scaleway VM in the private net.)

## What

Split the two flag channels:
- **apiserver flags** (`templates/talos/oidc-helper.yaml`) — validation only:
  `oidc-issuer-url`, `oidc-client-id`, `oidc-username-claim`, `oidc-groups-claim`.
  Rendered into the machine config as before.
- **client flags** (`templates/talos/oidc-client-secret.yaml`) — kubelogin
  exec-block flags (scopes, client secret) → a per-cluster **Secret** in the
  management cluster, labeled `cluster.x-k8s.io/cluster-name`. The UI reads
  it by that label and renders the flags verbatim into the served kubeconfig.

A Secret (not ConfigMap) because flags may carry `--oidc-client-secret`. It is
per-cluster and post-deploy mutable (`kubectl edit secret <cluster>-oidc-client`),
so client flags can change after Kommodity is running — no Kommodity redeploy,
no apiserver touch.

## Changes
- chart version `0.30.2` → `0.30.3`
- `oidc.yaml` → `oidc-helper.yaml` (apiserver flags only)
- new `oidc-client-secret.yaml` (client flags Secret)
- `values.yaml` / `values.azure.yaml`: `clientExtraFlags` documented as
  kubelogin/client flags
- `pkg/config`: `OIDCConfig.ExtraScopes` → `ClientExtraFlags`
- `pkg/ui/api/kubeconfig.go`: reads Secret by cluster-name label; drops the
  dead `oidc-extra-scope` apiserver-flag scavenging
- templates render `ClientExtraFlags` verbatim; removed the
  `--oidc-extra-scope={{ UsernameClaim }}` hack
- 5 new helm unit tests (287 passing)