### PR TITLE
fix(ui): use text/template for kubeconfig to avoid html escaping

### DIFF
--- a/pkg/ui/api/kubeconfig.go
+++ b/pkg/ui/api/kubeconfig.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
+	"text/template"
 	"os"
 	"sort"
 	"strings"


### PR DESCRIPTION
html/template auto-escapes quotes in the YAML kubeconfig, so sprig's quote emitted &#34; instead of ". The UI then re-escaped & to &amp;, producing &amp;#34; in the rendered args. Kubeconfig is YAML; switch to text/template so flags render literally.

Signed-off-by: Paul Thuriot <pth@corti.ai>
