### PR TITLE
fix(ui): base64-encode kubeconfig in cluster detail page

### DIFF
--- a/pkg/ui/router.go
+++ b/pkg/ui/router.go
@@ -29,9 +29,8 @@ import (
 // HTML-escape it; entities inside a <script> tag are not decoded by the browser,
 // so escaped quotes would render literally. The frontend decodes it via atob.
 type KubeconfigSection struct {
-	ID             string
-	Content        string
-	ContentBase64  string
+	ID            string
+	ContentBase64 string
 }
 
 // MetricCard holds data for a single metric card.
@@ -157,7 +156,6 @@ func (r *Router) handleApp(writer http.ResponseWriter, req *http.Request) {
 		"Version":  getKommodityVersion(),
 		"KubeconfigSection": KubeconfigSection{
 			ID:            "kommodity",
-			Content:       kubeconfigContent,
 			ContentBase64: base64.StdEncoding.EncodeToString([]byte(kubeconfigContent)),
 		},
 	}
@@ -473,7 +471,6 @@ func buildClusterDetailData(
 		"Version":        getKommodityVersion(),
 		"KubeconfigSection": KubeconfigSection{
 			ID:            clusterName,
-			Content:       kubeconfigContent,
 			ContentBase64: base64.StdEncoding.EncodeToString([]byte(kubeconfigContent)),
 		},
 	}

--- a/pkg/ui/router.go
+++ b/pkg/ui/router.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"embed"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,9 +25,13 @@ import (
 )
 
 // KubeconfigSection holds configuration for rendering a kubeconfig section.
+// ContentBase64 carries the kubeconfig base64-encoded so html/template cannot
+// HTML-escape it; entities inside a <script> tag are not decoded by the browser,
+// so escaped quotes would render literally. The frontend decodes it via atob.
 type KubeconfigSection struct {
-	ID      string
-	Content string
+	ID             string
+	Content        string
+	ContentBase64  string
 }
 
 // MetricCard holds data for a single metric card.
@@ -151,8 +156,9 @@ func (r *Router) handleApp(writer http.ResponseWriter, req *http.Request) {
 		"Clusters": clusters,
 		"Version":  getKommodityVersion(),
 		"KubeconfigSection": KubeconfigSection{
-			ID:      "kommodity",
-			Content: kubeconfigContent,
+			ID:            "kommodity",
+			Content:       kubeconfigContent,
+			ContentBase64: base64.StdEncoding.EncodeToString([]byte(kubeconfigContent)),
 		},
 	}
 
@@ -466,8 +472,9 @@ func buildClusterDetailData(
 		"HasAutoscaler":  hasAutoscaler,
 		"Version":        getKommodityVersion(),
 		"KubeconfigSection": KubeconfigSection{
-			ID:      clusterName,
-			Content: kubeconfigContent,
+			ID:            clusterName,
+			Content:       kubeconfigContent,
+			ContentBase64: base64.StdEncoding.EncodeToString([]byte(kubeconfigContent)),
 		},
 	}
 }

--- a/pkg/ui/templates/components/kubeconfig_section.html
+++ b/pkg/ui/templates/components/kubeconfig_section.html
@@ -55,7 +55,8 @@
     const contentEl = container.querySelector('.kubeconfig-content');
     const dataEl = document.getElementById('kubeconfig-data-{{.ID}}');
     // Content is base64-encoded to survive html/template without HTML-escaping.
-    const kubeconfigContent = dataEl && dataEl.textContent.trim() ? atob(dataEl.textContent.trim()) : '';
+    const rawBase64 = dataEl ? dataEl.textContent.trim() : '';
+    const kubeconfigContent = rawBase64 ? atob(rawBase64) : '';
 
     // Simple YAML syntax highlighter with line numbers
     function highlightYAML(yaml) {

--- a/pkg/ui/templates/components/kubeconfig_section.html
+++ b/pkg/ui/templates/components/kubeconfig_section.html
@@ -1,8 +1,8 @@
 {{define "kubeconfig_section.html"}}
 <div class="rounded-sm border border-gray-800 bg-gray-900 p-6"
      data-kubeconfig-id="{{.ID}}">
-    <!-- Hidden data container (XSS-safe) -->
-    <script type="text/plain" id="kubeconfig-data-{{.ID}}">{{.Content}}</script>
+    <!-- Hidden data container (XSS-safe): base64 so html/template can't mangle it -->
+    <script type="text/plain" id="kubeconfig-data-{{.ID}}">{{.ContentBase64}}</script>
 
     <details class="group">
         <summary class="flex items-center justify-between cursor-pointer list-none">
@@ -54,7 +54,8 @@
 
     const contentEl = container.querySelector('.kubeconfig-content');
     const dataEl = document.getElementById('kubeconfig-data-{{.ID}}');
-    const kubeconfigContent = dataEl ? dataEl.textContent : '';
+    // Content is base64-encoded to survive html/template without HTML-escaping.
+    const kubeconfigContent = dataEl && dataEl.textContent.trim() ? atob(dataEl.textContent.trim()) : '';
 
     // Simple YAML syntax highlighter with line numbers
     function highlightYAML(yaml) {


### PR DESCRIPTION
html/template escaped quotes in the kubeconfig embedded in <script type=text/plain>, and browsers do not decode HTML entities inside script tags, so the UI rendered literal &#34; instead of ". PR #482 fixed the API download path but the SSR cluster detail page still escaped. Base64-encode the content server-side and atob-decode it in the frontend so quotes survive intact.

Signed-off-by: Paul Thuriot <pth@corti.ai>
