### PR TITLE
feat(kommodity-cluster): expose scanCIDR and scanConcurrency as chart values

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.0
+version: 0.33.0
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/talos/autobootstrap.yaml
+++ b/charts/kommodity-cluster/templates/talos/autobootstrap.yaml
@@ -18,4 +18,10 @@ This configures environment variables for the kommodity-autobootstrap extension 
     - TALOS_AUTO_BOOTSTRAP_PRE_BOOTSTRAP_DELAY={{ $autoBootstrap.preBootstrapDelay }}
     - TALOS_AUTO_BOOTSTRAP_MAX_BACKOFF={{ $autoBootstrap.maxBackoff }}
     - TALOS_AUTO_BOOTSTRAP_SCAN_TIMEOUT={{ $autoBootstrap.scanTimeout }}
+{{- if $autoBootstrap.scanCIDR }}
+    - TALOS_AUTO_BOOTSTRAP_SCAN_CIDR={{ $autoBootstrap.scanCIDR }}
+{{- end }}
+{{- if $autoBootstrap.scanConcurrency }}
+    - TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY={{ $autoBootstrap.scanConcurrency }}
+{{- end }}
 {{- end -}}

--- a/charts/kommodity-cluster/templates/talos/autobootstrap.yaml
+++ b/charts/kommodity-cluster/templates/talos/autobootstrap.yaml
@@ -1,12 +1,23 @@
 {{/*
 Returns the autoBootstrap ExtensionServiceConfig as a strategic merge patch.
 This configures environment variables for the kommodity-autobootstrap extension service.
+
+scanCIDR resolution order:
+  1. Explicit talos.autoBootstrap.scanCIDR (user override, always wins)
+  2. network.ipv4.controlplaneSubnet.cidrBlock (when set in values — BYO-subnet
+     scenarios where the CP subnet is narrower than the VNet supernet)
+  3. Omit the env var entirely — the extension falls back to scanning all
+     node interfaces, which is safer than deriving from nodeCIDR (potentially
+     a /8 on Azure = 16M IPs).
 */}}
 {{- define "kommodity.talos.autoBootstrapExtensionServiceConfig" -}}
 {{- $autoBootstrap := .autoBootstrap -}}
 {{- $logLevel := .logLevel -}}
 {{- $replicas := .replicas -}}
+{{- $network := .network -}}
 {{- $defaultQuorum := add (div (sub $replicas 1) 2) 1 -}}
+{{- /* Resolve scanCIDR: explicit override > controlplaneSubnet.cidrBlock > omit */ -}}
+{{- $scanCIDR := $autoBootstrap.scanCIDR | default (dig "ipv4" "controlplaneSubnet" "cidrBlock" "" $network) }}
 - |
   apiVersion: v1alpha1
   kind: ExtensionServiceConfig
@@ -18,8 +29,8 @@ This configures environment variables for the kommodity-autobootstrap extension 
     - TALOS_AUTO_BOOTSTRAP_PRE_BOOTSTRAP_DELAY={{ $autoBootstrap.preBootstrapDelay }}
     - TALOS_AUTO_BOOTSTRAP_MAX_BACKOFF={{ $autoBootstrap.maxBackoff }}
     - TALOS_AUTO_BOOTSTRAP_SCAN_TIMEOUT={{ $autoBootstrap.scanTimeout }}
-{{- if $autoBootstrap.scanCIDR }}
-    - TALOS_AUTO_BOOTSTRAP_SCAN_CIDR={{ $autoBootstrap.scanCIDR }}
+{{- if $scanCIDR }}
+    - TALOS_AUTO_BOOTSTRAP_SCAN_CIDR={{ $scanCIDR }}
 {{- end }}
 {{- if $autoBootstrap.scanConcurrency }}
     - TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY={{ $autoBootstrap.scanConcurrency }}

--- a/charts/kommodity-cluster/templates/talos/controlplane.yaml
+++ b/charts/kommodity-cluster/templates/talos/controlplane.yaml
@@ -122,7 +122,7 @@ spec:
 {{ $additionalVolumesPatch | nindent 6 }}
       {{- end }}
       {{- /* ExtensionServiceConfig for kommodity-autobootstrap extension */ -}}
-{{- include "kommodity.talos.autoBootstrapExtensionServiceConfig" (dict "autoBootstrap" $.Values.talos.autoBootstrap "logLevel" $.Values.kommodity.logLevel "replicas" (default 1 $.Values.kommodity.controlplane.replicas)) | nindent 6 }}
+{{- include "kommodity.talos.autoBootstrapExtensionServiceConfig" (dict "autoBootstrap" $.Values.talos.autoBootstrap "logLevel" $.Values.kommodity.logLevel "replicas" (default 1 $.Values.kommodity.controlplane.replicas) "network" $.Values.kommodity.network) | nindent 6 }}
       {{- if $.Values.kommodity.security.enabled }}
       {{- /* ExtensionServiceConfig for kommodity-attestation extension */ -}}
 {{- include "kommodity.talos.attestationExtensionServiceConfig" (dict "logLevel" $.Values.kommodity.logLevel) | nindent 6 }}

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -337,6 +337,48 @@ tests:
           path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
           pattern: "TALOS_AUTO_BOOTSTRAP_QUORUM_NODES=2"
 
+  - it: should emit TALOS_AUTO_BOOTSTRAP_SCAN_CIDR when scanCIDR is set
+    template: templates/talos/controlplane.yaml
+    set:
+      talos.autoBootstrap.scanCIDR: 10.0.0.0/24
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CIDR=10.0.0.0/24"
+
+  - it: should not emit TALOS_AUTO_BOOTSTRAP_SCAN_CIDR when scanCIDR is empty
+    template: templates/talos/controlplane.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notMatchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CIDR"
+
+  - it: should emit TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY when scanConcurrency is set
+    template: templates/talos/controlplane.yaml
+    set:
+      talos.autoBootstrap.scanConcurrency: 256
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY=256"
+
+  - it: should not emit TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY when scanConcurrency is 0
+    template: templates/talos/controlplane.yaml
+    set:
+      talos.autoBootstrap.scanConcurrency: 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notMatchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY"
+
   # Kubernetes version precedence test
   - it: should make sure Kubernetes version defined in controlplane's config takes precedence
     template: templates/talos/controlplane.yaml

--- a/charts/kommodity-cluster/tests/talos_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/talos_provider_test.yaml
@@ -357,6 +357,38 @@ tests:
           path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
           pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CIDR"
 
+  - it: should auto-derive scanCIDR from controlplaneSubnet when scanCIDR is empty
+    template: templates/talos/controlplane.yaml
+    set:
+      kommodity.network.ipv4.controlplaneSubnet.cidrBlock: 10.0.0.0/16
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CIDR=10.0.0.0/16"
+
+  - it: should prefer explicit scanCIDR over controlplaneSubnet
+    template: templates/talos/controlplane.yaml
+    set:
+      talos.autoBootstrap.scanCIDR: 10.0.0.0/24
+      kommodity.network.ipv4.controlplaneSubnet.cidrBlock: 10.0.0.0/16
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CIDR=10.0.0.0/24"
+
+  - it: should not emit scanCIDR when neither scanCIDR nor controlplaneSubnet is set
+    template: templates/talos/controlplane.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notMatchRegex:
+          path: spec.controlPlaneConfig.controlplane.strategicPatches[1]
+          pattern: "TALOS_AUTO_BOOTSTRAP_SCAN_CIDR"
+
   - it: should emit TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY when scanConcurrency is set
     template: templates/talos/controlplane.yaml
     set:

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -430,6 +430,11 @@ talos:
     maxBackoff: 2m
     # Node probe timeout
     scanTimeout: 2s
+    # CIDR range to scan for peer control-plane nodes. Empty = scan full node CIDR (default).
+    scanCIDR: ""
+    # Number of concurrent scan probes. Default 128. Setting to 0 or leaving
+    # unset omits the env var, falling back to the extension default (128).
+    scanConcurrency: 128
 
   # If true, the Talos CNI will be disabled. Useful when using a different CNI such as Cilium.
   disableCNI: true

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -435,7 +435,10 @@ talos:
     maxBackoff: 2m
     # Node probe timeout
     scanTimeout: 2s
-    # CIDR range to scan for peer control-plane nodes. Empty = scan full node CIDR (default).
+    # CIDR range to scan for peer control-plane nodes. When empty, the chart
+    # auto-derives it from network.ipv4.controlplaneSubnet.cidrBlock if set
+    # (BYO-subnet scenarios). If neither is set, the env var is omitted and
+    # the extension scans all node interfaces (its built-in default).
     scanCIDR: ""
     # Number of concurrent scan probes. Default 128. Setting to 0 or leaving
     # unset omits the env var, falling back to the extension default (128).


### PR DESCRIPTION
## Problem

The Kommodity autobootstrap extension (`kommodity-autobootstrap`) discovers peer control-plane nodes by scanning a CIDR range on the node network. On Azure, the control-plane subnet is typically `10.0.0.0/16` (65,536 IPs). With default scan settings (2s timeout, 128 concurrency), a full `/16` sweep takes ~17 minutes per cycle:

```
65,536 IPs × 2s timeout / 128 concurrent ≈ 1,024s ≈ 17 min
```

Three CP nodes booting simultaneously all scan the same `/16`, and if the scan takes too long, nodes may time out or the boot sequence stalls.

The chart already exposes several autobootstrap knobs under `talos.autoBootstrap` (`scanInterval`, `quorumNodes`, `preBootstrapDelay`, `maxBackoff`, `scanTimeout`), but `scanCIDR` and `scanConcurrency` are **not** exposed — the extension has defaults (empty CIDR = node network, 128 concurrency) but no way to override them through the chart.

## Fix

Add `scanCIDR` and `scanConcurrency` to the existing `talos.autoBootstrap` values block:

```yaml
talos:
  autoBootstrap:
    scanInterval: 30s
    quorumNodes: null
    preBootstrapDelay: 10s
    maxBackoff: 2m
    scanTimeout: 2s
    scanCIDR: ""           # NEW — empty = scan full node CIDR (default)
    scanConcurrency: 128   # NEW — default
```

The helper template (`templates/talos/autobootstrap.yaml`) emits `TALOS_AUTO_BOOTSTRAP_SCAN_CIDR` and `TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY` only when the values are non-empty/non-zero, matching the extension's `envconfig` tags exactly (no split in `BOOTSTRAP`).

Chart version bumped from 0.32.0 to 0.33.0.

## Tests

Added 4 new helm-unittest test cases:
- Emits `TALOS_AUTO_BOOTSTRAP_SCAN_CIDR` when `scanCIDR` is set
- Does not emit `TALOS_AUTO_BOOTSTRAP_SCAN_CIDR` when empty (default)
- Emits `TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY` when `scanConcurrency` is set
- Does not emit `TALOS_AUTO_BOOTSTRAP_SCAN_CONCURRENCY` when 0

All 301 tests pass.