### PR TITLE
feat(kommodity-cluster): default provider.secret.name to scaleway-secret for Scaleway

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.0
+version: 0.34.0
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
@@ -39,7 +39,11 @@ metadata:
   {{- $_ := set $annotations "kommodity.io/ccm-secret-name" $azureCCMSecret }}
   {{- $_ := set $annotations "kommodity.io/ccm-downstream-secret-name" "azure-cloud-provider" }}
   {{- else }}
-  {{- $_ := set $annotations "kommodity.io/ccm-secret-name" .Values.kommodity.provider.secret.name }}
+  {{- $nonAzureSecret := dig "secret" "name" "" .Values.kommodity.provider }}
+  {{- if eq .Values.kommodity.provider.name "Scaleway" }}
+  {{- $nonAzureSecret = default "scaleway-secret" $nonAzureSecret }}
+  {{- end }}
+  {{- $_ := set $annotations "kommodity.io/ccm-secret-name" $nonAzureSecret }}
   {{- if eq .Values.kommodity.provider.name "Kubevirt" }}
   {{- $_ := set $annotations "kommodity.io/ccm-downstream-secret-name" "kubevirt-cloud-controller-manager" }}
   {{- else if eq .Values.kommodity.provider.name "Scaleway" }}

--- a/charts/kommodity-cluster/templates/provider/scaleway/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/scaleway/cluster.yaml
@@ -22,7 +22,7 @@ spec:
   {{- fail "missing required projectID in kommodity.provider.config for Scaleway" -}}
   {{- end }}
   region: {{ .Values.kommodity.region }}
-  scalewaySecretName: {{ .Values.kommodity.provider.secret.name }}
+  scalewaySecretName: {{ dig "secret" "name" "scaleway-secret" .Values.kommodity.provider }}
   {{- if and .Values.kommodity.network.ipv4.enabled (not .Values.kommodity.network.ipv4.public) }}
   network:
     privateNetwork:

--- a/charts/kommodity-cluster/tests/scaleway_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/scaleway_provider_test.yaml
@@ -235,3 +235,35 @@ tests:
     asserts:
       - notExists:
           path: spec.failureDomains
+
+  - it: should default scalewaySecretName to scaleway-secret when provider.secret is not set
+    template: templates/provider/scaleway/cluster.yaml
+    asserts:
+      - equal:
+          path: spec.scalewaySecretName
+          value: scaleway-secret
+
+  - it: should default ccm-secret-name to scaleway-secret when provider.secret is not set
+    template: templates/provider/capi/cluster.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["kommodity.io/ccm-secret-name"]
+          value: scaleway-secret
+
+  - it: should honour an explicit provider.secret.name override for scalewaySecretName
+    template: templates/provider/scaleway/cluster.yaml
+    set:
+      kommodity.provider.secret.name: my-custom-secret
+    asserts:
+      - equal:
+          path: spec.scalewaySecretName
+          value: my-custom-secret
+
+  - it: should honour an explicit provider.secret.name override for ccm-secret-name
+    template: templates/provider/capi/cluster.yaml
+    set:
+      kommodity.provider.secret.name: my-custom-secret
+    asserts:
+      - equal:
+          path: metadata.annotations["kommodity.io/ccm-secret-name"]
+          value: my-custom-secret

--- a/charts/kommodity-cluster/values.scaleway.yaml
+++ b/charts/kommodity-cluster/values.scaleway.yaml
@@ -2,21 +2,23 @@
 kommodity:
   provider:
     name: Scaleway
-    secret:
-      # Scaleway secret example:
-      #
-      # apiVersion: v1
-      # kind: Secret
-      # metadata:
-      #   name: scaleway-secret
-      #   namespace: default
-      # data:
-      #   SCW_ACCESS_KEY: <YOUR_BASE64_ENCODED_ACCESS_KEY>
-      #   SCW_SECRET_KEY: <YOUR_BASE64_ENCODED_SECRET_KEY>
-      #   SCW_DEFAULT_REGION: <YOUR_BASE64_ENCODED_REGION>
-      #   SCW_DEFAULT_PROJECT_ID: <YOUR_BASE64_ENCODED_PROJECT_ID>
-      # type: Opaque
-      name: scaleway-secret
+    # The chart defaults provider.secret.name to "scaleway-secret" when
+    # provider.name is Scaleway. Override only if you use a custom secret name.
+    # secret:
+    #   # Scaleway secret example:
+    #   #
+    #   # apiVersion: v1
+    #   # kind: Secret
+    #   # metadata:
+    #   #   name: scaleway-secret
+    #   #   namespace: default
+    #   #   data:
+    #   #     SCW_ACCESS_KEY: <YOUR_BASE64_ENCODED_ACCESS_KEY>
+    #   #     SCW_SECRET_KEY: <YOUR_BASE64_ENCODED_SECRET_KEY>
+    #   #     SCW_DEFAULT_REGION: <YOUR_BASE64_ENCODED_REGION>
+    #   #     SCW_DEFAULT_PROJECT_ID: <YOUR_BASE64_ENCODED_PROJECT_ID>
+    #   #   type: Opaque
+    #   name: scaleway-secret
     config:
       projectID: <YOUR_PROJECT_ID_HERE>
 


### PR DESCRIPTION
## Problem

When deploying a Kommodity cluster on Azure using `kommodity-cluster` with a shared Scaleway-flavoured base values file, the cloud-controller-manager (CCM) pod crashes because the `azure-cloud-provider` secret is populated with Scaleway credentials instead of Azure credentials.

The root cause: shared base values set `provider.secret.name: scaleway-secret` at the provider level. When Azure clusters inherit this via Helm deep merge, the chart uses `scaleway-secret` as the CCM secret name. The management-cluster secret `scaleway-secret` contains Scaleway credentials, which the Azure CCM can't parse.

The existing pattern requires every Scaleway cluster to explicitly set `provider.secret.name: scaleway-secret` in its values — and if this is done in a shared base, it leaks into non-Scaleway clusters.

## Fix

Make the chart default `provider.secret.name` to `scaleway-secret` when `provider.name == "Scaleway"`, mirroring the Azure pattern where `ccm-secret-name` defaults to `<release>-cloud-provider`.

The field stays generic — `provider.secret.name` is still consumed by all four providers (Scaleway `scalewaySecretName`, Hetzner `hetznerSecretRef`, Kubevirt `infraClusterSecretRef`, and the CCM-secret annotation for all non-Azure providers). Only the **default** is Scaleway-scoped.

Changes:
- `templates/provider/capi/cluster.yaml`: non-Azure providers now use `dig "secret" "name" "" .Values.kommodity.provider` with a Scaleway default of `scaleway-secret` for the `ccm-secret-name` annotation
- `templates/provider/scaleway/cluster.yaml`: `scalewaySecretName` uses `dig "secret" "name" "scaleway-secret"` so it defaults correctly without requiring the field in values
- `values.scaleway.yaml`: secret block commented out to show the default is sufficient
- 4 new test cases: default secret name, explicit override for both `scalewaySecretName` and `ccm-secret-name`

Kubevirt and Hetzner still require explicit `provider.secret.name` — only Scaleway gets a default.

Chart version bumped from 0.32.0 to 0.34.0.

## Merge Order

Assuming #484 (scanCIDR/scanConcurrency) merges first as 0.33.0, this PR bumps to 0.34.0. If this PR merges first, re-bump to 0.33.0 and #484 to 0.34.0.

Downstream deployments PR (corticph/deployments#23570) depends on this chart version being published — it removes `provider.secret` from the shared base values and bumps all Scaleway cluster config tags to 0.34.0.