### PR TITLE
chore(kommodity-cluster): move provider-specific config under provider.<name> subkey

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.0
+version: 1.0.0
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/files/kubevirt-ccm.yaml
+++ b/charts/kommodity-cluster/files/kubevirt-ccm.yaml
@@ -178,7 +178,7 @@ metadata:
   namespace: kube-system
 data:
   cloud-config: |
-    namespace: {{ .Values.kommodity.provider.config.infraClusterNamespace }}
+    namespace: {{ dig "Kubevirt" "config" "infraClusterNamespace" "" .Values.kommodity.provider }}
     kubeconfig: /etc/kubernetes/kubeconfig/value
 ---
 apiVersion: apps/v1

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -235,7 +235,7 @@ Any values that should trigger a new Machine template when changed should be add
 	{{- $_ := set $data "additionalVolumes" . -}}
 {{- end -}}
 {{- if eq .allValues.kommodity.provider.name "Kubevirt" -}}
-{{- $effectiveEvictionStrategy := default "LiveMigrateIfPossible" (dig "evictionStrategy" "" (default dict .allValues.kommodity.provider.config)) -}}
+{{- $effectiveEvictionStrategy := default "LiveMigrateIfPossible" (dig "Kubevirt" "config" "evictionStrategy" "" .allValues.kommodity.provider) -}}
 {{- $_ := set $data "evictionStrategy" $effectiveEvictionStrategy -}}
 {{- if (dig "spreadAcrossHosts" false .poolValues) -}}
 {{- $_ := set $data "spreadAcrossHosts" true -}}
@@ -347,7 +347,7 @@ credential materializer refuses to take over a Secret owned by another cluster â
 see ErrSecretOwnedByAnotherCluster â€” so this template intentionally does not
 constrain provider.secret.name, which has a legitimate custom-override use case.)
 
-Set kommodity.provider.config.allowSharedResourceGroup: true to intentionally
+Set kommodity.provider.Azure.config.allowSharedResourceGroup: true to intentionally
 place multiple clusters in one resource group (you are then responsible for
 non-colliding resource names and CIDRs).
 
@@ -355,10 +355,10 @@ Usage: {{ include "kommodity.azure.validateNaming" . }}
 */}}
 {{- define "kommodity.azure.validateNaming" -}}
 {{- if eq .Values.kommodity.provider.name "Azure" -}}
-{{- if not (dig "config" "allowSharedResourceGroup" false .Values.kommodity.provider) -}}
-{{- $rg := dig "config" "resourceGroup" "" .Values.kommodity.provider -}}
+{{- if not (dig "Azure" "config" "allowSharedResourceGroup" false .Values.kommodity.provider) -}}
+{{- $rg := dig "Azure" "config" "resourceGroup" "" .Values.kommodity.provider -}}
 {{- if and $rg (ne $rg .Release.Name) -}}
-{{- fail (printf "Azure resourceGroup %q does not match the Helm release name %q. This usually means a values file was copied from another cluster without updating kommodity.provider.config.resourceGroup, which would make this release share the other cluster's resource group and corrupt both. Rename the resource group to %q, or set kommodity.provider.config.allowSharedResourceGroup=true to intentionally share one." $rg .Release.Name .Release.Name) -}}
+{{- fail (printf "Azure resourceGroup %q does not match the Helm release name %q. This usually means a values file was copied from another cluster without updating kommodity.provider.Azure.config.resourceGroup, which would make this release share the other cluster's resource group and corrupt both. Rename the resource group to %q, or set kommodity.provider.Azure.config.allowSharedResourceGroup=true to intentionally share one." $rg .Release.Name .Release.Name) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -402,11 +402,11 @@ computeGallery:
 {{- else if dig "id" "" $talos -}}
 id: {{ $talos.id }}
 {{- else if dig "imageName" "" $talos -}}
-{{- $subID := required "talos.imageName requires kommodity.provider.config.subscriptionID to build the Talos image resource ID" (dig "config" "subscriptionID" "" .Values.kommodity.provider) -}}
-{{- $imageRG := required "talos.imageName requires kommodity.provider.config.talosImageResourceGroup (the resource group holding the Talos managed image) to build the Talos image resource ID" (dig "config" "talosImageResourceGroup" "" .Values.kommodity.provider) -}}
+{{- $subID := required "talos.imageName requires kommodity.provider.Azure.config.subscriptionID to build the Talos image resource ID" (dig "Azure" "config" "subscriptionID" "" .Values.kommodity.provider) -}}
+{{- $imageRG := required "talos.imageName requires kommodity.provider.Azure.config.talosImageResourceGroup (the resource group holding the Talos managed image) to build the Talos image resource ID" (dig "Azure" "config" "talosImageResourceGroup" "" .Values.kommodity.provider) -}}
 id: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s" $subID $imageRG $talos.imageName }}
 {{- else -}}
-{{- fail "no Talos image configured for Azure: set talos.imageName (recommended) together with kommodity.provider.config.talosImageResourceGroup, or use talos.id / talos.computeGallery / talos.marketplace" -}}
+{{- fail "no Talos image configured for Azure: set talos.imageName (recommended) together with kommodity.provider.Azure.config.talosImageResourceGroup, or use talos.id / talos.computeGallery / talos.marketplace" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/cluster.yaml
@@ -11,23 +11,23 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep # Prevent Helm from deleting the resource on uninstall, deletion will be handled by CAPI
 spec:
-  {{- if dig "config" "subscriptionID" "" .Values.kommodity.provider }}
-  subscriptionID: {{ .Values.kommodity.provider.config.subscriptionID }}
+  {{- if dig "Azure" "config" "subscriptionID" "" .Values.kommodity.provider }}
+  subscriptionID: {{ (dig "Azure" "config" "subscriptionID" "" .Values.kommodity.provider) }}
   {{- else }}
-  {{- fail "missing required subscriptionID in kommodity.provider.config for Azure" -}}
+  {{- fail "missing required subscriptionID in kommodity.provider.Azure.config for Azure" -}}
   {{- end }}
-  {{- $rg := dig "config" "resourceGroup" "" .Values.kommodity.provider | default .Release.Name }}
+  {{- $rg := dig "Azure" "config" "resourceGroup" "" .Values.kommodity.provider | default .Release.Name }}
   resourceGroup: {{ $rg }}
-  {{- if dig "config" "location" "" .Values.kommodity.provider }}
-  location: {{ .Values.kommodity.provider.config.location }}
+  {{- if dig "Azure" "config" "location" "" .Values.kommodity.provider }}
+  location: {{ (dig "Azure" "config" "location" "" .Values.kommodity.provider) }}
   {{- else }}
-  {{- fail "missing required location in kommodity.provider.config for Azure" -}}
+  {{- fail "missing required location in kommodity.provider.Azure.config for Azure" -}}
   {{- end }}
-  {{- if .Values.kommodity.provider.identity }}
+  {{- if dig "Azure" "identity" (dict) .Values.kommodity.provider }}
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
-    name: {{ .Values.kommodity.provider.identity.name }}
+    name: {{ (dig "Azure" "identity" "name" "" .Values.kommodity.provider) }}
     namespace: {{ .Release.Namespace }}
   {{- end }}
   {{- if gt (len $zones) 0 }}

--- a/charts/kommodity-cluster/templates/provider/azure/networkresources.yaml
+++ b/charts/kommodity-cluster/templates/provider/azure/networkresources.yaml
@@ -33,7 +33,7 @@
 {{- $nodeNSGName := printf "%s-node-nsg" .Release.Name }}
 {{- $rtName := printf "%s-node-routetable" .Release.Name }}
 {{- $asoSecret := printf "%s-aso-secret" .Release.Name }}
-{{- $location := required "missing required location in kommodity.provider.config for Azure" (dig "config" "location" "" .Values.kommodity.provider) }}
+{{- $location := required "missing required location in kommodity.provider.Azure.config for Azure" (dig "Azure" "config" "location" "" .Values.kommodity.provider) }}
 ---
 apiVersion: network.azure.com/v1api20240301
 kind: NetworkSecurityGroup

--- a/charts/kommodity-cluster/templates/provider/byot/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/byot/cluster.yaml
@@ -1,7 +1,7 @@
 {{- if eq .Values.kommodity.provider.name "Byot" }}
-{{- $endpoint := dig "config" "controlPlaneEndpoint" (dict) .Values.kommodity.provider }}
+{{- $endpoint := dig "Byot" "config" "controlPlaneEndpoint" (dict) .Values.kommodity.provider }}
 {{- if not (dig "host" "" (default (dict) $endpoint)) }}
-{{- fail "kommodity.provider.config.controlPlaneEndpoint.host is required for Byot (a VIP/LB/DNS name fronting the control plane, or one committed CP host IP; CP host IPs are resolved at claim time so cannot be auto-derived)" -}}
+{{- fail "kommodity.provider.Byot.config.controlPlaneEndpoint.host is required for Byot (a VIP/LB/DNS name fronting the control plane, or one committed CP host IP; CP host IPs are resolved at claim time so cannot be auto-derived)" -}}
 {{- end }}
 {{- $endpointPort := 6443 }}
 {{- if dig "port" nil (default (dict) $endpoint) }}

--- a/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/cluster.yaml
@@ -31,20 +31,27 @@ metadata:
     Azure's CCM cloud-config Secret is materialized per cluster (not hand-created),
     so its management-side name defaults to <release>-cloud-provider — unique per
     release, letting multiple Azure clusters share one namespace without colliding.
-    An explicit provider.secret.name overrides it (e.g. to point at a Secret you
+    An explicit provider.Azure.secret.name overrides it (e.g. to point at a Secret you
     manage yourself). The downstream name inside each workload cluster is always
     azure-cloud-provider (separate clusters, no collision).
   */}}
-  {{- $azureCCMSecret := dig "secret" "name" "" .Values.kommodity.provider | default (printf "%s-cloud-provider" .Release.Name) }}
+  {{- $azureProvider := dig "Azure" (dict) .Values.kommodity.provider }}
+  {{- $azureCCMSecret := dig "secret" "name" "" $azureProvider | default (printf "%s-cloud-provider" .Release.Name) }}
   {{- $_ := set $annotations "kommodity.io/ccm-secret-name" $azureCCMSecret }}
   {{- $_ := set $annotations "kommodity.io/ccm-downstream-secret-name" "azure-cloud-provider" }}
   {{- else }}
-  {{- $_ := set $annotations "kommodity.io/ccm-secret-name" .Values.kommodity.provider.secret.name }}
-  {{- if eq .Values.kommodity.provider.name "Kubevirt" }}
+  {{- $providerName := .Values.kommodity.provider.name }}
+  {{- $providerConfig := dig $providerName (dict) .Values.kommodity.provider }}
+  {{- $ccmSecretName := dig "secret" "name" "" $providerConfig }}
+  {{- if and (eq $providerName "Scaleway") (not $ccmSecretName) }}
+  {{- $ccmSecretName = "scaleway-secret" }}
+  {{- end }}
+  {{- $_ := set $annotations "kommodity.io/ccm-secret-name" $ccmSecretName }}
+  {{- if eq $providerName "Kubevirt" }}
   {{- $_ := set $annotations "kommodity.io/ccm-downstream-secret-name" "kubevirt-cloud-controller-manager" }}
-  {{- else if eq .Values.kommodity.provider.name "Scaleway" }}
+  {{- else if eq $providerName "Scaleway" }}
   {{- $_ := set $annotations "kommodity.io/ccm-downstream-secret-name" "scaleway-secret" }}
-  {{- else if eq .Values.kommodity.provider.name "Hetzner" }}
+  {{- else if eq $providerName "Hetzner" }}
   {{- /* hcloud CCM and CSI both expect the token Secret to be named "hcloud". */}}
   {{- $_ := set $annotations "kommodity.io/ccm-downstream-secret-name" "hcloud" }}
   {{- end }}

--- a/charts/kommodity-cluster/templates/provider/hetzner/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/hetzner/cluster.yaml
@@ -1,7 +1,7 @@
 {{- if eq .Values.kommodity.provider.name "Hetzner" }}
 {{- $privateNetwork := and .Values.kommodity.network.ipv4.enabled (not .Values.kommodity.network.ipv4.public) }}
 {{- /* `config:` with no value is valid YAML for null, which dig cannot walk. */}}
-{{- $config := .Values.kommodity.provider.config | default dict }}
+{{- $config := dig "Hetzner" "config" (dict) .Values.kommodity.provider | default (dict) }}
 {{- /*
   The hcloud-csi addon mounts the `hcloud` Secret that only the CCM
   ClusterResourceSet delivers, so the combination is rejected at render time
@@ -37,7 +37,7 @@ spec:
     host: {{ dig "host" "" $cpe | quote }}
     port: {{ dig "port" 6443 $cpe }}
   hetznerSecretRef:
-    name: {{ .Values.kommodity.provider.secret.name }}
+    name: {{ dig "Hetzner" "secret" "name" "" .Values.kommodity.provider }}
     key:
       hcloudToken: hcloud
   {{- with (dig "sshKeyName" "" $config) }}

--- a/charts/kommodity-cluster/templates/provider/kubevirt/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/kubevirt/cluster.yaml
@@ -1,4 +1,7 @@
 {{- if eq .Values.kommodity.provider.name "Kubevirt" }}
+{{- $provider := dig "Kubevirt" (dict) .Values.kommodity.provider }}
+{{- $config := dig "config" (dict) $provider }}
+{{- $secret := dig "secret" (dict) $provider }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtCluster
 metadata:
@@ -8,20 +11,20 @@ metadata:
     app.kubernetes.io/managed-by: kommodity
 spec:
   infraClusterSecretRef:
-    name: {{ .Values.kommodity.provider.secret.name }}
+    name: {{ dig "name" "" $secret }}
     namespace: {{ .Release.Namespace }}
   controlPlaneServiceTemplate:
     metadata:
-      namespace: {{ .Values.kommodity.provider.config.infraClusterNamespace }}
-      {{- with (dig "provider" "config" "controlPlaneServiceTemplate" "annotations" dict .Values.kommodity) }}
+      namespace: {{ dig "infraClusterNamespace" "" $config }}
+      {{- with (dig "annotations" (dict) (dig "controlPlaneServiceTemplate" (dict) $config)) }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      type: {{ dig "provider" "config" "controlPlaneServiceTemplate" "spec" "type" "LoadBalancer" .Values.kommodity }}
-  {{- if dig "provider" "config" "controlPlaneEndpoint" "" .Values.kommodity }}
+      type: {{ dig "controlPlaneServiceTemplate" "spec" "type" "LoadBalancer" $config }}
+  {{- if dig "controlPlaneEndpoint" "" $config }}
   controlPlaneEndpoint:
-    host: {{ .Values.kommodity.provider.config.controlPlaneEndpoint.host }}
-    port: {{ .Values.kommodity.provider.config.controlPlaneEndpoint.port }}
+    host: {{ dig "controlPlaneEndpoint" "host" "" $config }}
+    port: {{ dig "controlPlaneEndpoint" "port" 6443 $config }}
   {{- end }}
 {{- end }}

--- a/charts/kommodity-cluster/templates/provider/kubevirt/machinetemplate.yaml
+++ b/charts/kommodity-cluster/templates/provider/kubevirt/machinetemplate.yaml
@@ -1,6 +1,7 @@
 {{- if eq .Values.kommodity.provider.name "Kubevirt" }}
 {{- $ifType := dig "network" "cluster" "interfaceType" "bridge" .Values.kommodity }}
-{{- $defaultStorageClass := dig "provider" "config" "storageClassName" "" .Values.kommodity -}}
+{{- $config := dig "Kubevirt" "config" (dict) .Values.kommodity.provider }}
+{{- $defaultStorageClass := dig "storageClassName" "" $config -}}
 {{- $cpSku := dig "sku" "" .Values.kommodity.controlplane -}}
 {{- $cpResources := dig "resources" "" .Values.kommodity.controlplane -}}
 {{- if and $cpSku $cpResources -}}
@@ -31,12 +32,12 @@ spec:
         checkStrategy: none
       virtualMachineTemplate:
         metadata:
-          namespace: {{ .Values.kommodity.provider.config.infraClusterNamespace }}
+          namespace: {{ dig "infraClusterNamespace" "" $config }}
         spec:
           dataVolumeTemplates:
             - metadata:
                 name: boot-volume
-                namespace: {{ $.Values.kommodity.provider.config.infraClusterNamespace }}
+                namespace: {{ dig "infraClusterNamespace" "" $config }}
               spec:
                 pvc:
                   resources:
@@ -44,8 +45,8 @@ spec:
                       storage: {{ .Values.kommodity.controlplane.os.disk.size }}Gi
                   accessModes:
                     - ReadWriteOnce
-                  {{- if hasKey .Values.kommodity.provider.config "storageClassName" }}
-                  storageClassName: {{ .Values.kommodity.provider.config.storageClassName }}
+                  {{- if hasKey $config "storageClassName" }}
+                  storageClassName: {{ $config.storageClassName }}
                   {{- end }}
                   volumeMode: Filesystem
                 source:
@@ -92,7 +93,7 @@ spec:
                     - disk:
                         bus: virtio
                       name: dv-volume
-              evictionStrategy: {{ default "LiveMigrateIfPossible" $.Values.kommodity.provider.config.evictionStrategy | quote }}
+              evictionStrategy: {{ default "LiveMigrateIfPossible" (dig "evictionStrategy" "" $config) | quote }}
               volumes:
                 - dataVolume:
                     name: boot-volume
@@ -141,12 +142,12 @@ spec:
         checkStrategy: none
       virtualMachineTemplate:
         metadata:
-          namespace: {{ $.Values.kommodity.provider.config.infraClusterNamespace }}
+          namespace: {{ dig "infraClusterNamespace" "" $config }}
         spec:
           dataVolumeTemplates:
             - metadata:
                 name: boot-volume
-                namespace: {{ $.Values.kommodity.provider.config.infraClusterNamespace }}
+                namespace: {{ dig "infraClusterNamespace" "" $config }}
               spec:
                 pvc:
                   resources:
@@ -154,8 +155,8 @@ spec:
                       storage: {{ $np.os.disk.size }}Gi
                   accessModes:
                     - ReadWriteOnce
-                  {{- if hasKey $.Values.kommodity.provider.config "storageClassName" }}
-                  storageClassName: {{ $.Values.kommodity.provider.config.storageClassName }}
+                  {{- if hasKey $config "storageClassName" }}
+                  storageClassName: {{ $config.storageClassName }}
                   {{- end }}
                   volumeMode: Filesystem
                 source:
@@ -165,7 +166,7 @@ spec:
             {{- $volStorageClass := default $defaultStorageClass (dig "storageClassName" "" $vol) }}
             - metadata:
                 name: additional-volume-{{ $idx }}
-                namespace: {{ $.Values.kommodity.provider.config.infraClusterNamespace }}
+                namespace: {{ dig "infraClusterNamespace" "" $config }}
               spec:
                 pvc:
                   resources:
@@ -233,7 +234,7 @@ spec:
                         bus: virtio
                       name: additional-volume-{{ $idx }}
                     {{- end }}
-              evictionStrategy: {{ default "LiveMigrateIfPossible" $.Values.kommodity.provider.config.evictionStrategy | quote }}
+              evictionStrategy: {{ default "LiveMigrateIfPossible" (dig "evictionStrategy" "" $config) | quote }}
               volumes:
                 - dataVolume:
                     name: boot-volume

--- a/charts/kommodity-cluster/templates/provider/scaleway/cluster.yaml
+++ b/charts/kommodity-cluster/templates/provider/scaleway/cluster.yaml
@@ -16,13 +16,14 @@ spec:
     - {{ . }}
   {{- end }}
   {{- end }}
-  {{- if hasKey .Values.kommodity.provider.config "projectID" }}
-  projectID: {{ .Values.kommodity.provider.config.projectID }}
+  {{- $scaleway := dig "Scaleway" (dict) .Values.kommodity.provider }}
+  {{- if hasKey (dig "config" (dict) $scaleway) "projectID" }}
+  projectID: {{ $scaleway.config.projectID }}
   {{- else }}
-  {{- fail "missing required projectID in kommodity.provider.config for Scaleway" -}}
+  {{- fail "missing required projectID in kommodity.provider.Scaleway.config for Scaleway" -}}
   {{- end }}
   region: {{ .Values.kommodity.region }}
-  scalewaySecretName: {{ .Values.kommodity.provider.secret.name }}
+  scalewaySecretName: {{ dig "secret" "name" "scaleway-secret" $scaleway | default "scaleway-secret" }}
   {{- if and .Values.kommodity.network.ipv4.enabled (not .Values.kommodity.network.ipv4.public) }}
   network:
     privateNetwork:

--- a/charts/kommodity-cluster/tests/azure_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_cluster_test.yaml
@@ -58,7 +58,7 @@ tests:
 
   - it: should not include identityRef when identity is not configured
     set:
-      kommodity.provider.identity: null
+      kommodity.provider.Azure.identity: null
     asserts:
       - notExists:
           path: spec.identityRef
@@ -96,14 +96,14 @@ tests:
 
   - it: should fail when subscriptionID is missing
     set:
-      kommodity.provider.config.subscriptionID: null
+      kommodity.provider.Azure.config.subscriptionID: null
     asserts:
       - failedTemplate:
-          errorMessage: "missing required subscriptionID in kommodity.provider.config for Azure"
+          errorMessage: "missing required subscriptionID in kommodity.provider.Azure.config for Azure"
 
   - it: should default resourceGroup to the release name when not set
     set:
-      kommodity.provider.config.resourceGroup: null
+      kommodity.provider.Azure.config.resourceGroup: null
     asserts:
       - equal:
           path: spec.resourceGroup
@@ -111,10 +111,10 @@ tests:
 
   - it: should fail when location is missing
     set:
-      kommodity.provider.config.location: null
+      kommodity.provider.Azure.config.location: null
     asserts:
       - failedTemplate:
-          errorMessage: "missing required location in kommodity.provider.config for Azure"
+          errorMessage: "missing required location in kommodity.provider.Azure.config for Azure"
 
   - it: should include internal apiServerLB and full networkSpec when cluster is private
     asserts:
@@ -364,16 +364,16 @@ tests:
   # updated to match the new release name) must fail fast at render time.
   - it: should fail when resourceGroup does not match the release name
     set:
-      kommodity.provider.config.resourceGroup: some-other-cluster
+      kommodity.provider.Azure.config.resourceGroup: some-other-cluster
     asserts:
       - failedTemplate:
-          errorMessage: 'Azure resourceGroup "some-other-cluster" does not match the Helm release name "test-cluster". This usually means a values file was copied from another cluster without updating kommodity.provider.config.resourceGroup, which would make this release share the other cluster''s resource group and corrupt both. Rename the resource group to "test-cluster", or set kommodity.provider.config.allowSharedResourceGroup=true to intentionally share one.'
+          errorMessage: 'Azure resourceGroup "some-other-cluster" does not match the Helm release name "test-cluster". This usually means a values file was copied from another cluster without updating kommodity.provider.Azure.config.resourceGroup, which would make this release share the other cluster''s resource group and corrupt both. Rename the resource group to "test-cluster", or set kommodity.provider.Azure.config.allowSharedResourceGroup=true to intentionally share one.'
 
   # The opt-in escape hatch disables the resource-group check for intentional sharing.
   - it: should allow a mismatched resourceGroup when allowSharedResourceGroup is set
     set:
-      kommodity.provider.config.resourceGroup: shared-rg
-      kommodity.provider.config.allowSharedResourceGroup: true
+      kommodity.provider.Azure.config.resourceGroup: shared-rg
+      kommodity.provider.Azure.config.allowSharedResourceGroup: true
     asserts:
       - isKind:
           of: AzureCluster

--- a/charts/kommodity-cluster/tests/azure_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/azure_provider_test.yaml
@@ -37,10 +37,10 @@ tests:
           path: metadata.annotations["kommodity.io/ccm-secret-name"]
           value: test-cluster-cloud-provider
 
-  - it: should honour an explicit provider.secret.name override for ccm-secret-name
+  - it: should honour an explicit provider.Azure.secret.name override for ccm-secret-name
     template: templates/provider/capi/cluster.yaml
     set:
-      kommodity.provider.secret.name: my-own-cloud-provider
+      kommodity.provider.Azure.secret.name: my-own-cloud-provider
     asserts:
       - equal:
           path: metadata.annotations["kommodity.io/ccm-secret-name"]
@@ -397,8 +397,8 @@ tests:
   - it: should build the image id from imageName + talosImageResourceGroup
     template: templates/provider/azure/machinetemplate.yaml
     set:
-      kommodity.provider.config.subscriptionID: sub-1234
-      kommodity.provider.config.talosImageResourceGroup: shared-images-rg
+      kommodity.provider.Azure.config.subscriptionID: sub-1234
+      kommodity.provider.Azure.config.talosImageResourceGroup: shared-images-rg
       talos.imageName: kommodity-talos-azure-v1.13.0
     asserts:
       - equal:
@@ -414,11 +414,11 @@ tests:
   - it: should require talosImageResourceGroup when only imageName is set
     template: templates/provider/azure/machinetemplate.yaml
     set:
-      kommodity.provider.config.talosImageResourceGroup: null
+      kommodity.provider.Azure.config.talosImageResourceGroup: null
       talos.imageName: kommodity-talos-azure-v1.13.0
     asserts:
       - failedTemplate:
-          errorMessage: talos.imageName requires kommodity.provider.config.talosImageResourceGroup (the resource group holding the Talos managed image) to build the Talos image resource ID
+          errorMessage: talos.imageName requires kommodity.provider.Azure.config.talosImageResourceGroup (the resource group holding the Talos managed image) to build the Talos image resource ID
 
   # Escape hatch: an explicit full ARM id takes precedence over imageName.
   - it: should use an explicit image id when configured

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -32,15 +32,15 @@ tests:
   - it: should fail when controlPlaneEndpoint.host is unset
     template: templates/provider/byot/cluster.yaml
     set:
-      kommodity.provider.config.controlPlaneEndpoint: null
+      kommodity.provider.Byot.config.controlPlaneEndpoint: null
     asserts:
       - failedTemplate:
-          errorMessage: "kommodity.provider.config.controlPlaneEndpoint.host is required for Byot (a VIP/LB/DNS name fronting the control plane, or one committed CP host IP; CP host IPs are resolved at claim time so cannot be auto-derived)"
+          errorMessage: "kommodity.provider.Byot.config.controlPlaneEndpoint.host is required for Byot (a VIP/LB/DNS name fronting the control plane, or one committed CP host IP; CP host IPs are resolved at claim time so cannot be auto-derived)"
 
   - it: should default the endpoint port to 6443 when only host is set
     template: templates/provider/byot/cluster.yaml
     set:
-      kommodity.provider.config.controlPlaneEndpoint:
+      kommodity.provider.Byot.config.controlPlaneEndpoint:
         host: 198.51.100.5
     asserts:
       - equal:

--- a/charts/kommodity-cluster/tests/ccm_test.yaml
+++ b/charts/kommodity-cluster/tests/ccm_test.yaml
@@ -241,7 +241,7 @@ tests:
       - ../values.kubevirt.yaml
     set:
       kommodity.network.ipv4.nodeCIDR: "10.200.0.0/20"
-      kommodity.provider.config.infraClusterNamespace: my-infra-ns
+      kommodity.provider.Kubevirt.config.infraClusterNamespace: my-infra-ns
     documentSelector:
       path: kind
       value: ConfigMap

--- a/charts/kommodity-cluster/tests/hetzner_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/hetzner_provider_test.yaml
@@ -156,7 +156,7 @@ tests:
   - it: should render when provider config is null rather than an empty map
     template: templates/provider/hetzner/cluster.yaml
     set:
-      kommodity.provider.config: null
+      kommodity.provider.Hetzner.config: null
     asserts:
       - isKind:
           of: HetznerCluster

--- a/charts/kommodity-cluster/tests/kubevirt_cluster_test.yaml
+++ b/charts/kommodity-cluster/tests/kubevirt_cluster_test.yaml
@@ -81,7 +81,7 @@ tests:
   - it: should honor controlPlaneServiceTemplate annotations and type from values
     template: templates/provider/kubevirt/cluster.yaml
     set:
-      kommodity.provider.config.controlPlaneServiceTemplate:
+      kommodity.provider.Kubevirt.config.controlPlaneServiceTemplate:
         annotations:
           service.beta.kubernetes.io/scw-loadbalancer-zone: fr-par-1
         spec:

--- a/charts/kommodity-cluster/tests/kubevirt_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/kubevirt_provider_test.yaml
@@ -87,7 +87,7 @@ tests:
         documentIndex: 1
   - it: should produce the same template-name hash whether evictionStrategy is unset or explicitly LiveMigrateIfPossible
     set:
-      kommodity.provider.config.evictionStrategy: LiveMigrateIfPossible
+      kommodity.provider.Kubevirt.config.evictionStrategy: LiveMigrateIfPossible
     template: templates/provider/kubevirt/machinetemplate.yaml
     asserts:
       - equal:
@@ -100,7 +100,7 @@ tests:
         documentIndex: 1
   - it: should honor a custom evictionStrategy override on both controlplane and worker
     set:
-      kommodity.provider.config.evictionStrategy: None
+      kommodity.provider.Kubevirt.config.evictionStrategy: None
     template: templates/provider/kubevirt/machinetemplate.yaml
     asserts:
       - equal:
@@ -215,7 +215,7 @@ tests:
   - it: should render additionalVolumes on worker nodepool
     template: templates/provider/kubevirt/machinetemplate.yaml
     set:
-      kommodity.provider.config.storageClassName: ceph-block
+      kommodity.provider.Kubevirt.config.storageClassName: ceph-block
       kommodity.nodepools.default.additionalVolumes:
         - size: 50
         - size: 100

--- a/charts/kommodity-cluster/tests/scaleway_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/scaleway_provider_test.yaml
@@ -235,3 +235,39 @@ tests:
     asserts:
       - notExists:
           path: spec.failureDomains
+
+  - it: should default scalewaySecretName to scaleway-secret when provider.Scaleway.secret is not set
+    template: templates/provider/scaleway/cluster.yaml
+    set:
+      kommodity.provider.Scaleway.secret.name: ""
+    asserts:
+      - equal:
+          path: spec.scalewaySecretName
+          value: scaleway-secret
+
+  - it: should default ccm-secret-name to scaleway-secret when provider.Scaleway.secret is not set
+    template: templates/provider/capi/cluster.yaml
+    set:
+      kommodity.provider.Scaleway.secret.name: ""
+    asserts:
+      - equal:
+          path: metadata.annotations["kommodity.io/ccm-secret-name"]
+          value: scaleway-secret
+
+  - it: should honour an explicit provider.Scaleway.secret.name override for scalewaySecretName
+    template: templates/provider/scaleway/cluster.yaml
+    set:
+      kommodity.provider.Scaleway.secret.name: my-custom-secret
+    asserts:
+      - equal:
+          path: spec.scalewaySecretName
+          value: my-custom-secret
+
+  - it: should honour an explicit provider.Scaleway.secret.name override for ccm-secret-name
+    template: templates/provider/capi/cluster.yaml
+    set:
+      kommodity.provider.Scaleway.secret.name: my-custom-secret
+    asserts:
+      - equal:
+          path: metadata.annotations["kommodity.io/ccm-secret-name"]
+          value: my-custom-secret

--- a/charts/kommodity-cluster/values.azure.yaml
+++ b/charts/kommodity-cluster/values.azure.yaml
@@ -10,45 +10,45 @@ kommodity:
     # `<release>-cloud-provider` (unique per release), so multiple Azure clusters can
     # share one namespace without colliding. The only Azure secret you create by hand
     # is the AzureClusterIdentity's clientSecret Secret (see identity, below).
-    #
-    # secret:
-    #   # Optional override: point at a Secret you manage yourself instead. The
-    #   # materializer leaves any Secret without its managed-by label untouched.
-    #   name: my-cloud-provider-secret
-    identity:
-      name: azure-cluster-identity
-      # AzureClusterIdentity resource name for authentication.
-      # Create this resource in the management cluster before deploying:
-      #
-      # apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      # kind: AzureClusterIdentity
-      # metadata:
-      #   name: azure-cluster-identity
-      #   namespace: default
-      # spec:
-      #   type: ServicePrincipal
-      #   tenantID: <YOUR_TENANT_ID>
-      #   clientID: <YOUR_CLIENT_ID>
-      #   clientSecret:
-      #     name: azure-cluster-identity-secret
-      #     namespace: default
-      #   allowedNamespaces: {}
-    config:
-      subscriptionID: <YOUR_SUBSCRIPTION_ID>
-      # Optional: defaults to the Helm release name. The chart fails fast at
-      # install time if an explicitly-set resourceGroup does not match the
-      # release name — this catches a values file copied from another cluster
-      # without updating this field, which would otherwise silently share that
-      # cluster's resource group and corrupt both. Set allowSharedResourceGroup:
-      # true below to place multiple clusters in one resource group on purpose.
-      # resourceGroup: <YOUR_RESOURCE_GROUP>
-      location: westeurope
-      # Resource group that holds the Talos managed image referenced by
-      # talos.imageName. Combined with subscriptionID above, the chart builds the
-      # full image ARM ID, so you only provide the image name (Scaleway-aligned).
-      # May differ from the cluster resourceGroup (images are often shared).
-      talosImageResourceGroup: <YOUR_IMAGE_RESOURCE_GROUP>
-      # allowSharedResourceGroup: true   # opt out of the release-name == RG check
+    Azure:
+      # secret:
+      #   # Optional override: point at a Secret you manage yourself instead. The
+      #   # materializer leaves any Secret without its managed-by label untouched.
+      #   name: my-cloud-provider-secret
+      identity:
+        name: azure-cluster-identity
+        # AzureClusterIdentity resource name for authentication.
+        # Create this resource in the management cluster before deploying:
+        #
+        # apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        # kind: AzureClusterIdentity
+        # metadata:
+        #   name: azure-cluster-identity
+        #   namespace: default
+        # spec:
+        #   type: ServicePrincipal
+        #   tenantID: <YOUR_TENANT_ID>
+        #   clientID: <YOUR_CLIENT_ID>
+        #   clientSecret:
+        #     name: azure-cluster-identity-secret
+        #     namespace: default
+        #   allowedNamespaces: {}
+      config:
+        subscriptionID: <YOUR_SUBSCRIPTION_ID>
+        # Optional: defaults to the Helm release name. The chart fails fast at
+        # install time if an explicitly-set resourceGroup does not match the
+        # release name — this catches a values file copied from another cluster
+        # without updating this field, which would otherwise silently share that
+        # cluster's resource group and corrupt both. Set allowSharedResourceGroup:
+        # true below to place multiple clusters in one resource group on purpose.
+        # resourceGroup: <YOUR_RESOURCE_GROUP>
+        location: westeurope
+        # Resource group that holds the Talos managed image referenced by
+        # talos.imageName. Combined with subscriptionID above, the chart builds the
+        # full image ARM ID, so you only provide the image name (Scaleway-aligned).
+        # May differ from the cluster resourceGroup (images are often shared).
+        talosImageResourceGroup: <YOUR_IMAGE_RESOURCE_GROUP>
+        # allowSharedResourceGroup: true   # opt out of the release-name == RG check
 
     cloudControllerManager:
       enabled: true

--- a/charts/kommodity-cluster/values.byot.yaml
+++ b/charts/kommodity-cluster/values.byot.yaml
@@ -5,13 +5,14 @@
 kommodity:
   provider:
     name: Byot
-    # Control-plane endpoint (REQUIRED). Must exist before any host
-    # is claimed. CP host IPs are resolved at claim time and cannot be used
-    # here (VIP / load balancer / DNS name fronting the control plane (HA)).
-    config:
-      controlPlaneEndpoint:
-        host: 203.0.113.10
-        port: 6443
+    Byot:
+      # Control-plane endpoint (REQUIRED). Must exist before any host
+      # is claimed. CP host IPs are resolved at claim time and cannot be used
+      # here (VIP / load balancer / DNS name fronting the control plane (HA)).
+      config:
+        controlPlaneEndpoint:
+          host: 203.0.113.10
+          port: 6443
 
   network:
     ipv4:

--- a/charts/kommodity-cluster/values.hetzner.yaml
+++ b/charts/kommodity-cluster/values.hetzner.yaml
@@ -19,46 +19,47 @@
 kommodity:
   provider:
     name: Hetzner
-    secret:
-      # Hetzner secret example (one read/write API token per Hetzner project,
-      # Console -> Security -> API tokens):
-      #
-      #   kubectl --kubeconfig kommodity.yaml create secret generic hetzner \
-      #     --from-literal=hcloud=$HCLOUD_TOKEN
-      #
-      # Both the token and Hetzner's rate limit (3600 requests/hour, refilling
-      # one per second) are project-scoped and shared with everything else in
-      # the project - cluster-autoscaler's default scan interval can exhaust it
-      # on its own - so use one project per set of related clusters.
-      name: hetzner
-    # IMMUTABLE AFTER CREATE: CAPH treats hcloudNetwork, loadBalancer.enabled,
-    # controlPlaneEndpoint.port and region (the LB region) as immutable on
-    # HetznerCluster. Kommodity does not run CAPH's validating webhooks, so a
-    # helm upgrade changing any of them is accepted by the API server but has
-    # no effect. Recreate the cluster instead.
-    config:
-      # Hetzner location for the control plane and its load balancer:
-      # one of fsn1, nbg1, hel1, ash, hil, sin (default fsn1).
-      region: fsn1
-      # Optional: name of an SSH key pre-uploaded to the Hetzner project.
-      # Talos has no SSH, so this is usually left unset.
-      # sshKeyName: my-ssh-key
+    Hetzner:
+      secret:
+        # Hetzner secret example (one read/write API token per Hetzner project,
+        # Console -> Security -> API tokens):
+        #
+        #   kubectl --kubeconfig kommodity.yaml create secret generic hetzner \
+        #     --from-literal=hcloud=$HCLOUD_TOKEN
+        #
+        # Both the token and Hetzner's rate limit (3600 requests/hour, refilling
+        # one per second) are project-scoped and shared with everything else in
+        # the project - cluster-autoscaler's default scan interval can exhaust it
+        # on its own - so use one project per set of related clusters.
+        name: hetzner
+      # IMMUTABLE AFTER CREATE: CAPH treats hcloudNetwork, loadBalancer.enabled,
+      # controlPlaneEndpoint.port and region (the LB region) as immutable on
+      # HetznerCluster. Kommodity does not run CAPH's validating webhooks, so a
+      # helm upgrade changing any of them is accepted by the API server but has
+      # no effect. Recreate the cluster instead.
+      config:
+        # Hetzner location for the control plane and its load balancer:
+        # one of fsn1, nbg1, hel1, ash, hil, sin (default fsn1).
+        region: fsn1
+        # Optional: name of an SSH key pre-uploaded to the Hetzner project.
+        # Talos has no SSH, so this is usually left unset.
+        # sshKeyName: my-ssh-key
 
-      # Control-plane load balancer (created by CAPH, enabled by default).
-      # Disable it for single-control-plane setups and set controlPlaneEndpoint
-      # to a DNS name pointing at the control-plane machine instead.
-      # loadBalancer:
-      #   enabled: true    # immutable after create
-      #   # One of lb11, lb21, lb31 (default lb11).
-      #   type: lb11
-      # controlPlaneEndpoint:
-      #   host: cp.example.com
-      #   port: 6443       # immutable after create
+        # Control-plane load balancer (created by CAPH, enabled by default).
+        # Disable it for single-control-plane setups and set controlPlaneEndpoint
+        # to a DNS name pointing at the control-plane machine instead.
+        # loadBalancer:
+        #   enabled: true    # immutable after create
+        #   # One of lb11, lb21, lb31 (default lb11).
+        #   type: lb11
+        # controlPlaneEndpoint:
+        #   host: cp.example.com
+        #   port: 6443       # immutable after create
 
-      # Network zone of the private network when kommodity.network.ipv4.public
-      # is false. One of eu-central (fsn1/nbg1/hel1, the default), us-east (ash),
-      # us-west (hil), ap-southeast (sin).
-      # networkZone: eu-central
+        # Network zone of the private network when kommodity.network.ipv4.public
+        # is false. One of eu-central (fsn1/nbg1/hel1, the default), us-east (ash),
+        # us-west (hil), ap-southeast (sin).
+        # networkZone: eu-central
 
     cloudControllerManager:
       enabled: true

--- a/charts/kommodity-cluster/values.kubevirt.yaml
+++ b/charts/kommodity-cluster/values.kubevirt.yaml
@@ -2,47 +2,47 @@
 kommodity:
   provider:
     name: Kubevirt
-    secret:
-      # Kubevirt secret example (contains a kubeconfig used to connect to the Kubevirt cluster):
-      #
-      # apiVersion: v1
-      # kind: Secret
-      # metadata:
-      #   name: kubevirt-credentials
-      #   namespace: <release-namespace>
-      # data:
-      #   kubeconfig: <base64-encoded-kubeconfig>
-      # type: Opaque
-      name: kubevirt-credentials
-
     cloudControllerManager:
       enabled: true
       image:
         repository: quay.io/kubevirt/kubevirt-cloud-controller-manager
         tag: v0.6.0
 
-    config:
-      # Namespace in the external Kubevirt cluster where the VMs will be deployed
-      infraClusterNamespace: kubevirt-cluster-namespace
+    Kubevirt:
+      secret:
+        # Kubevirt secret example (contains a kubeconfig used to connect to the Kubevirt cluster):
+        #
+        # apiVersion: v1
+        # kind: Secret
+        # metadata:
+        #   name: kubevirt-credentials
+        #   namespace: <release-namespace>
+        # data:
+        #   kubeconfig: <base64-encoded-kubeconfig>
+        # type: Opaque
+        name: kubevirt-credentials
 
-      # Specify a storageClassName if needed
-      # storageClassName: my-storage-class
+      config:
+        # Namespace in the external Kubevirt cluster where the VMs will be deployed
+        infraClusterNamespace: kubevirt-cluster-namespace
 
-      # Specify a controlPlaneServiceTemplate if needed
-      # Defaults: no annotations, spec.type=LoadBalancer
-      # controlPlaneServiceTemplate:
-      #   annotations:
-      #     my-annotation: my-value
-      #   spec:
-      #     type: LoadBalancer # Valid values are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+        # Specify a storageClassName if needed
+        # storageClassName: my-storage-class
 
-      # Specify a controlPlaneEndpoint if needed
-      # controlPlaneEndpoint:
-      #   host: my-host-ip
-      #   port: 6443
+        # Specify a controlPlaneServiceTemplate if needed
+        # Defaults: no annotations, spec.type=LoadBalancer
+        # controlPlaneServiceTemplate:
+        #   annotations:
+        #     my-annotation: my-value
+        #   spec:
+        #     type: LoadBalancer # Valid values are ExternalName, ClusterIP, NodePort, and LoadBalancer.
 
-      # evictionStrategy: "LiveMigrateIfPossible" # Valid values: "LiveMigrateIfPossible", "LiveMigrate", "None", "External"
+        # Specify a controlPlaneEndpoint if needed
+        # controlPlaneEndpoint:
+        #   host: my-host-ip
+        #   port: 6443
 
+        # evictionStrategy: "LiveMigrateIfPossible" # Valid values: "LiveMigrateIfPossible", "LiveMigrate", "None", "External"
   global:
     strategicPatches:
       # Required when using a Cloud Controller Manager (https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager)

--- a/charts/kommodity-cluster/values.scaleway.yaml
+++ b/charts/kommodity-cluster/values.scaleway.yaml
@@ -2,24 +2,26 @@
 kommodity:
   provider:
     name: Scaleway
-    secret:
-      # Scaleway secret example:
-      #
-      # apiVersion: v1
-      # kind: Secret
-      # metadata:
+    Scaleway:
+      # The chart defaults provider.Scaleway.secret.name to "scaleway-secret".
+      # Override only if you use a custom secret name.
+      # secret:
+      #   # Scaleway secret example:
+      #   #
+      #   # apiVersion: v1
+      #   # kind: Secret
+      #   # metadata:
+      #   #   name: scaleway-secret
+      #   #   namespace: default
+      #   #   data:
+      #   #     SCW_ACCESS_KEY: <YOUR_BASE64_ENCODED_ACCESS_KEY>
+      #   #     SCW_SECRET_KEY: <YOUR_BASE64_ENCODED_SECRET_KEY>
+      #   #     SCW_DEFAULT_REGION: <YOUR_BASE64_ENCODED_REGION>
+      #   #     SCW_DEFAULT_PROJECT_ID: <YOUR_BASE64_ENCODED_PROJECT_ID>
+      #   #   type: Opaque
       #   name: scaleway-secret
-      #   namespace: default
-      # data:
-      #   SCW_ACCESS_KEY: <YOUR_BASE64_ENCODED_ACCESS_KEY>
-      #   SCW_SECRET_KEY: <YOUR_BASE64_ENCODED_SECRET_KEY>
-      #   SCW_DEFAULT_REGION: <YOUR_BASE64_ENCODED_REGION>
-      #   SCW_DEFAULT_PROJECT_ID: <YOUR_BASE64_ENCODED_PROJECT_ID>
-      # type: Opaque
-      name: scaleway-secret
-    config:
-      projectID: <YOUR_PROJECT_ID_HERE>
-
+      config:
+        projectID: <YOUR_PROJECT_ID_HERE>
     cloudControllerManager:
       enabled: true
       image:


### PR DESCRIPTION
## Breaking Change — Chart 1.0.0

Provider-specific configuration fields (`secret`, `config`, `identity`) have moved from the generic `kommodity.provider.*` level to `provider.<providerName>.*` subkeys. This prevents cross-provider value leakage via Helm deep merge (e.g. Scaleway's `scaleway-secret` leaking into Azure clusters).

`provider.name` and `provider.cloudControllerManager` remain at the generic `provider.*` level (shared across all providers).

### Migration Guide

#### Scaleway clusters

```yaml
# Before
kommodity:
  provider:
    name: Scaleway
    config:
      projectID: <your-project-id>

# After
kommodity:
  provider:
    name: Scaleway
    Scaleway:
      config:
        projectID: <your-project-id>
```

The `provider.secret` block is no longer needed — the chart defaults `provider.Scaleway.secret.name` to `scaleway-secret` when unset. Remove any explicit `provider.secret` from your values.

#### Azure clusters

```yaml
# Before
kommodity:
  provider:
    name: Azure
    identity:
      name: azure-cluster-identity
    config:
      subscriptionID: <your-subscription-id>
      location: westeurope
      resourceGroup: my-cluster-rg
      talosImageResourceGroup: shared-infra

# After
kommodity:
  provider:
    name: Azure
    Azure:
      identity:
        name: azure-cluster-identity
      config:
        subscriptionID: <your-subscription-id>
        location: westeurope
        resourceGroup: my-cluster-rg
        talosImageResourceGroup: shared-infra
```

#### Kubevirt clusters

```yaml
# Before
kommodity:
  provider:
    name: Kubevirt
    secret:
      name: my-credentials
    config:
      infraClusterNamespace: my-namespace
      storageClassName: ceph-block

# After
kommodity:
  provider:
    name: Kubevirt
    Kubevirt:
      secret:
        name: my-credentials
      config:
        infraClusterNamespace: my-namespace
        storageClassName: ceph-block
```

#### Hetzner clusters

```yaml
# Before
kommodity:
  provider:
    name: Hetzner
    config:
      networkZone: eu-central

# After
kommodity:
  provider:
    name: Hetzner
    Hetzner:
      config:
        networkZone: eu-central
```

### What stays the same

- `provider.name` — unchanged, stays at generic level
- `provider.cloudControllerManager` — unchanged, stays at generic level (shared CCM config)
- All non-provider values (network, talos, oidc, etc.) — unchanged

### Chart tag bump

Bump the chart tag in your cluster's `config.yaml` (or `config.disable.yaml`) from `0.33.0` (or earlier) to `1.0.0`.

## Supersedes

- kommodity-io/kommodity#485 (Scaleway default secret — folded into this PR)
