### PR TITLE
feat(chart): add nodeDrainTimeout/nodeDeletionTimeout to nodepool Machine template spec

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.0
+version: 0.32.1
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/capi/machinedeployment.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/machinedeployment.yaml
@@ -128,6 +128,14 @@ spec:
         {{- end }}
         name: {{ $.Release.Name }}-worker-{{ $name }}{{ $tmplSuffix }}-{{ include "kommodity-cluster.machineSpecsHash" (dict "poolValues" $np "allValues" $.Values) }}
         namespace: {{ $.Release.Namespace }}
+      {{- $nodeDrainTimeout := dig "nodeDrainTimeout" "" $np }}
+      {{- if $nodeDrainTimeout }}
+      nodeDrainTimeout: {{ $nodeDrainTimeout | quote }}
+      {{- end }}
+      {{- $nodeDeletionTimeout := dig "nodeDeletionTimeout" "" $np }}
+      {{- if $nodeDeletionTimeout }}
+      nodeDeletionTimeout: {{ $nodeDeletionTimeout | quote }}
+      {{- end }}
       version: {{ default $.Values.kubernetes.version (dig "kubernetes" "version" "" $np) -}}
 {{- end }}
 {{- end }}

--- a/charts/kommodity-cluster/tests/capi_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/capi_provider_test.yaml
@@ -312,3 +312,33 @@ tests:
       - equal:
           path: spec.template.spec.version
           value: "nodepool-kubernetes-version"
+
+  # Test nodeDrainTimeout / nodeDeletionTimeout are rendered into the Machine template spec
+  - it: should render nodeDrainTimeout and nodeDeletionTimeout into the Machine template spec when set on the nodepool
+    template: templates/provider/capi/machinedeployment.yaml
+    set:
+      kommodity.nodepools.default.nodeDrainTimeout: "10m0s"
+      kommodity.nodepools.default.nodeDeletionTimeout: "30s"
+    asserts:
+      - isKind:
+          of: MachineDeployment
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.nodeDrainTimeout
+          value: "10m0s"
+      - equal:
+          path: spec.template.spec.nodeDeletionTimeout
+          value: "30s"
+
+  - it: should omit nodeDrainTimeout and nodeDeletionTimeout when not set on the nodepool
+    template: templates/provider/capi/machinedeployment.yaml
+    asserts:
+      - isKind:
+          of: MachineDeployment
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.template.spec.nodeDrainTimeout
+      - notExists:
+          path: spec.template.spec.nodeDeletionTimeout

--- a/charts/kommodity-cluster/tests/capi_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/capi_provider_test.yaml
@@ -333,6 +333,9 @@ tests:
 
   - it: should omit nodeDrainTimeout and nodeDeletionTimeout when not set on the nodepool
     template: templates/provider/capi/machinedeployment.yaml
+    set:
+      kommodity.nodepools.default.nodeDrainTimeout: null
+      kommodity.nodepools.default.nodeDeletionTimeout: null
     asserts:
       - isKind:
           of: MachineDeployment

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -355,20 +355,18 @@ kommodity:
     #   #   - zone1
     #   #   - zone2
 
-    #   # Configurations related the specific nodepool
     #   # Using Talos strategic merge patches: https://docs.siderolabs.com/talos/v1.12/configure-your-talos-cluster/system-configuration/patching
     #   strategicPatches: {}
     #   # Kubernetes version can be overridden here, otherwise the top-level kubernetes.version is used
 
     #   kubernetes:
     #     version: v1.33.4
-    #   # Drain/delete timeouts applied to the Machine template spec. nodeDrainTimeout
-    #   # bounds how long CAPI waits for pod eviction before force-deleting the node;
-    #   # unset (default) means CAPI waits indefinitely, so PDB-blocked drains can
-    #   # stall a rolling update forever. nodeDeletionTimeout bounds node object
-    #   # deletion after the drain succeeds (CAPI default 10s).
-    #   nodeDrainTimeout: 10m0s
-    #   nodeDeletionTimeout: 10s
+
+    #   # Drain/delete timeouts: bounds how long CAPI waits for pod eviction 
+    #   # before force-deleting the node.
+    #   nodeDrainTimeout: 10m0s # default waits indefinitely
+    #   nodeDeletionTimeout: 10s # node deletion timeout after the drain succeeds (default 10s)
+
     #   # Talos version and imageName can be overridden here, otherwise the top-level talos.version and talos.imageName are used
     #   talos:
     #     version: v1.13.0

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -362,6 +362,13 @@ kommodity:
 
     #   kubernetes:
     #     version: v1.33.4
+    #   # Drain/delete timeouts applied to the Machine template spec. nodeDrainTimeout
+    #   # bounds how long CAPI waits for pod eviction before force-deleting the node;
+    #   # unset (default) means CAPI waits indefinitely, so PDB-blocked drains can
+    #   # stall a rolling update forever. nodeDeletionTimeout bounds node object
+    #   # deletion after the drain succeeds (CAPI default 10s).
+    #   nodeDrainTimeout: 10m0s
+    #   nodeDeletionTimeout: 10s
     #   # Talos version and imageName can be overridden here, otherwise the top-level talos.version and talos.imageName are used
     #   talos:
     #     version: v1.13.0


### PR DESCRIPTION
Add per-nodepool `nodeDrainTimeout` and `nodeDeletionTimeout`, rendered into the MachineDeployment `template.spec`.

## Why

CAPI `nodeDrainTimeout` defaults to `0` = drain waits indefinitely with no time limit. When a drain is blocked by a PodDisruptionBudget (PDB with `healthy=0`, or strict `maxUnavailable:0` workloads like mimir), the Machine sits `Deleting/Draining` forever and the rolling update stalls mid-way.

This caused the big node-roll stalls seen on `prd-par01` and `stg-par01` after the registry-mirror Talos patch (PR deployments#23561): old MachineSets scaled to 0, but 10+ machines per nodepool stuck draining for hours/days behind PDBs, blocking the new MachineSet from growing (`maxUnavailable:0, maxSurge:1`).

Setting `nodeDrainTimeout` lets CAPI give up on a blocked drain after a bounded duration and proceed to delete the node, so the rollout can complete.

## What

- `kommodity.nodepools.<name>.nodeDrainTimeout` → `spec.template.spec.nodeDrainTimeout`
- `kommodity.nodepools.<name>.nodeDeletionTimeout` → `spec.template.spec.nodeDeletionTimeout`
- Both optional; omitted when unset (preserves CAPI defaults: drain indefinite, deletion 10s).
- Documented in `values.yaml` nodepool example.
- Tests cover both set and unset cases.

## Usage

```yaml
kommodity:
  nodepools:
    default:
      nodeDrainTimeout: 10m0s
      nodeDeletionTimeout: 10s
```