### PR TITLE
feat(chart): make machinedeployment rollingUpdate maxSurge/maxUnavailable configurable

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.0
+version: 0.33.1
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/provider/capi/machinedeployment.yaml
+++ b/charts/kommodity-cluster/templates/provider/capi/machinedeployment.yaml
@@ -71,8 +71,8 @@ spec:
 {{- end }}
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ dig "rollingUpdate" "maxSurge" 1 $np }}
+      maxUnavailable: {{ dig "rollingUpdate" "maxUnavailable" 0 $np }}
     type: RollingUpdate
   selector:
     matchLabels: null

--- a/charts/kommodity-cluster/tests/capi_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/capi_provider_test.yaml
@@ -345,3 +345,36 @@ tests:
           path: spec.template.spec.nodeDrainTimeout
       - notExists:
           path: spec.template.spec.nodeDeletionTimeout
+
+  # Test rollingUpdate.maxSurge / maxUnavailable are rendered into the
+  # MachineDeployment strategy when set on the nodepool.
+  - it: should render rollingUpdate.maxSurge and maxUnavailable when set on the nodepool
+    template: templates/provider/capi/machinedeployment.yaml
+    set:
+      kommodity.nodepools.default.rollingUpdate.maxSurge: 3
+      kommodity.nodepools.default.rollingUpdate.maxUnavailable: 0
+    asserts:
+      - isKind:
+          of: MachineDeployment
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 3
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
+  - it: should default rollingUpdate.maxSurge to 1 and maxUnavailable to 0 when unset
+    template: templates/provider/capi/machinedeployment.yaml
+    asserts:
+      - isKind:
+          of: MachineDeployment
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0

--- a/charts/kommodity-cluster/values.yaml
+++ b/charts/kommodity-cluster/values.yaml
@@ -366,6 +366,12 @@ kommodity:
     #   # before force-deleting the node.
     #   nodeDrainTimeout: 10m0s # default waits indefinitely
     #   nodeDeletionTimeout: 10s # node deletion timeout after the drain succeeds (default 10s)
+    #
+    #   # Rolling update strategy for the MachineDeployment. Higher maxSurge lets
+    #   # replacement machines join before old ones are removed; keep maxUnavailable at 0 for storage nodepools.
+    #   rollingUpdate:
+    #     maxSurge: 1       # default 1
+    #     maxUnavailable: 0 # default 0
 
     #   # Talos version and imageName can be overridden here, otherwise the top-level talos.version and talos.imageName are used
     #   talos:


### PR DESCRIPTION
Let nodepools override the MachineDeployment rolling update strategy so storage nodepools can raise maxSurge (new machines join before old are removed, shrinking the window where a drained node holds unique OSD data) while keeping maxUnavailable at 0. Defaults preserve current behavior (maxSurge 1, maxUnavailable 0).

Signed-off-by: Paul Thuriot <pth@corti.ai>
