### PR TITLE
feat(chart): round memory/disk byot labels instead of fixed buckets

### DIFF
--- a/charts/kommodity-cluster/Chart.yaml
+++ b/charts/kommodity-cluster/Chart.yaml
@@ -9,6 +9,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.0
+version: 0.35.0
 # The downstream Talos version deployed by the chart.
 appVersion: "1.13.0"

--- a/charts/kommodity-cluster/templates/_helpers.tpl
+++ b/charts/kommodity-cluster/templates/_helpers.tpl
@@ -447,10 +447,10 @@ by the caller.
      Not validated; passed through verbatim when set. */ -}}
 {{- $cpu := dig "resources" "cpu" "" $p -}}
 {{- if and $cpu (not (hasKey $labels "byot.io/cpu-cores")) -}}{{- $_ := set $labels "byot.io/cpu-cores" $cpu -}}{{- end -}}
-{{- /* resources.memory -> byot.io/memory-class, OPTIONAL. Not validated;
+{{- /* resources.memory -> byot.io/memory, OPTIONAL. Not validated;
      passed through verbatim when set. */ -}}
 {{- $memory := dig "resources" "memory" "" $p -}}
-{{- if and $memory (not (hasKey $labels "byot.io/memory-class")) -}}{{- $_ := set $labels "byot.io/memory-class" $memory -}}{{- end -}}
+{{- if and $memory (not (hasKey $labels "byot.io/memory")) -}}{{- $_ := set $labels "byot.io/memory" $memory -}}{{- end -}}
 {{- $gpu := default (dict) (dig "resources" "gpu" (dict) $p) -}}
 {{- $gpuCount := dig "count" "" $gpu | toString -}}
 {{- $gpuModel := dig "model" "" $gpu -}}
@@ -477,7 +477,6 @@ by the caller.
 {{- $diskType := dig "type" "" $disk -}}
 {{- $diskSize := dig "size" "" $disk -}}
 {{- $diskTypes := list "nvme" "ssd" "hdd" "sd" -}}
-{{- $diskClasses := list "20G" "100G" "250G" "500G" "1T" -}}
 {{- if or $diskType $diskSize -}}
 {{- if not $diskType -}}
 {{- fail (printf "%s.os.disk.type is required when os.disk.size is set (one of: nvme ssd hdd sd); omit both for a disk-agnostic selector" $scope) -}}
@@ -486,13 +485,13 @@ by the caller.
 {{- fail (printf "%s.os.disk.type must be one of nvme ssd hdd sd (lowercase, matching the controller-promoted byot.io/disk-type label), got %q" $scope $diskType) -}}
 {{- end -}}
 {{- if not $diskSize -}}
-{{- fail (printf "%s.os.disk.size is required when os.disk.type is set (one of: 20G 100G 250G 500G 1T); omit both for a disk-agnostic selector" $scope) -}}
+{{- fail (printf "%s.os.disk.size is required when os.disk.type is set (a rounded value like 250G or 1T, matching the controller-promoted byot.io/disk-size label); omit both for a disk-agnostic selector" $scope) -}}
 {{- end -}}
-{{- if not (has $diskSize $diskClasses) -}}
-{{- fail (printf "%s.os.disk.size must be one of 20G 100G 250G 500G 1T (exact bucket matching the controller-promoted byot.io/disk-class label), got %q" $scope $diskSize) -}}
+{{- if not (regexMatch "^[0-9]+[GT]$" $diskSize) -}}
+{{- fail (printf "%s.os.disk.size must be a rounded value like 250G or 1T (integer + G/T suffix, matching the controller-promoted byot.io/disk-size label), got %q" $scope $diskSize) -}}
 {{- end -}}
 {{- if not (hasKey $labels "byot.io/disk-type") -}}{{- $_ := set $labels "byot.io/disk-type" $diskType -}}{{- end -}}
-{{- if not (hasKey $labels "byot.io/disk-class") -}}{{- $_ := set $labels "byot.io/disk-class" $diskSize -}}{{- end -}}
+{{- if not (hasKey $labels "byot.io/disk-size") -}}{{- $_ := set $labels "byot.io/disk-size" $diskSize -}}{{- end -}}
 {{- end -}}
 {{- /* byot.io/available is force-injected last; it cannot be overridden. */ -}}
 {{- $_ := set $labels "byot.io/available" "true" -}}

--- a/charts/kommodity-cluster/tests/byot_provider_test.yaml
+++ b/charts/kommodity-cluster/tests/byot_provider_test.yaml
@@ -110,13 +110,13 @@ tests:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/cpu-cores"]
           value: "4"
       - equal:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory"]
           value: 16G
       - equal:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/disk-type"]
           value: ssd
       - equal:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/disk-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/disk-size"]
           value: 100G
       - notExists:
           path: spec.template.spec.failureDomain
@@ -233,7 +233,7 @@ tests:
       kommodity.controlplane.os.disk.size: null
     asserts:
       - failedTemplate:
-          errorMessage: 'kommodity.controlplane.os.disk.size is required when os.disk.type is set (one of: 20G 100G 250G 500G 1T); omit both for a disk-agnostic selector'
+          errorMessage: 'kommodity.controlplane.os.disk.size is required when os.disk.type is set (a rounded value like 250G or 1T, matching the controller-promoted byot.io/disk-size label); omit both for a disk-agnostic selector'
 
   - it: should fail when os.disk.size is set but os.disk.type is unset
     template: templates/provider/byot/machinetemplate.yaml
@@ -243,13 +243,13 @@ tests:
       - failedTemplate:
           errorMessage: 'kommodity.controlplane.os.disk.type is required when os.disk.size is set (one of: nvme ssd hdd sd); omit both for a disk-agnostic selector'
 
-  - it: should fail when os.disk.size is not a valid bucket
+  - it: should fail when os.disk.size is not a valid rounded value
     template: templates/provider/byot/machinetemplate.yaml
     set:
-      kommodity.controlplane.os.disk.size: "50G"
+      kommodity.controlplane.os.disk.size: "50"
     asserts:
       - failedTemplate:
-          errorMessage: 'kommodity.controlplane.os.disk.size must be one of 20G 100G 250G 500G 1T (exact bucket matching the controller-promoted byot.io/disk-class label), got "50G"'
+          errorMessage: 'kommodity.controlplane.os.disk.size must be a rounded value like 250G or 1T (integer + G/T suffix, matching the controller-promoted byot.io/disk-size label), got "50"'
 
   # Optional os.disk: omitting both yields a disk-agnostic selector (no byot.io/disk-* labels)
   - it: should omit byot.io/disk-* labels when both os.disk fields are unset
@@ -261,12 +261,12 @@ tests:
       - notExists:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/disk-type"]
       - notExists:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/disk-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/disk-size"]
       - equal:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/cpu-cores"]
           value: "4"
       - equal:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory"]
           value: 16G
       - equal:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/available"]
@@ -324,10 +324,10 @@ tests:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/cpu-cores"]
           value: "4000m"
       - equal:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory"]
           value: 256G
 
-  - it: should omit byot.io/cpu-cores and byot.io/memory-class when unset
+  - it: should omit byot.io/cpu-cores and byot.io/memory when unset
     template: templates/provider/byot/machinetemplate.yaml
     documentIndex: 0
     set:
@@ -337,7 +337,7 @@ tests:
       - notExists:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/cpu-cores"]
       - notExists:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory"]
 
   - it: should fail when gpu is set without model
     template: templates/provider/byot/machinetemplate.yaml
@@ -400,7 +400,7 @@ tests:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/cpu-cores"]
           value: "8"
       - equal:
-          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory-class"]
+          path: spec.template.spec.hostSelector.matchLabels["byot.io/memory"]
           value: 16G
       - equal:
           path: spec.template.spec.hostSelector.matchLabels["byot.io/available"]

--- a/charts/kommodity-cluster/values.byot.yaml
+++ b/charts/kommodity-cluster/values.byot.yaml
@@ -25,11 +25,11 @@ kommodity:
     # matching them (exact-match).
     resources:
       cpu: "4" # Required
-      memory: "16G" # Required (one of 4G 8G 16G 32G 64G 128G)
+      memory: "16G" # Required (rounded value like 16G, 64G, 1T)
     os:
       disk:
         type: ssd # Optional (one of nvme ssd hdd sd)
-        size: "100G" # Optional (one of 20G 100G 250G 500G 1T)
+        size: "100G" # Optional (rounded value like 100G, 250G, 1T)
     # zones:
     #   - par01
     #   - par02

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/k3s-io/kine v1.14.2
-	github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.7.0
+	github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.8.0
 	github.com/scaleway/cluster-api-provider-scaleway v0.1.6
 	github.com/siderolabs/cluster-api-bootstrap-provider-talos v0.6.12
 	github.com/siderolabs/cluster-api-control-plane-provider-talos v0.5.13

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/tt
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.7.0 h1:DZwvW5RJXxNRjprbIEXJIBxk6nFe4G7afU5Ntzd9sSs=
-github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.7.0/go.mod h1:bFrSZ1WsSfwvQ9eM2whAKMWXaqnV5K7s/IH9JdB77Lo=
+github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.8.0 h1:elz0aGH37nKANQq4VNM102VYKFqmnJWg0Dy9kS4mn48=
+github.com/kommodity-io/cluster-api-provider-bringyourowntalos v0.8.0/go.mod h1:bFrSZ1WsSfwvQ9eM2whAKMWXaqnV5K7s/IH9JdB77Lo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/test/byot_test.go
+++ b/pkg/test/byot_test.go
@@ -147,20 +147,20 @@ func buildByotInfraFromDiscoveredHosts(t *testing.T, clusterName string, nodes b
 	t.Logf("discovered byot.io/ labels on %s: %v", nodes.CPHost, labels)
 
 	cpu := labels["byot.io/cpu-cores"]
-	memory := labels["byot.io/memory-class"]
+	memory := labels["byot.io/memory"]
 	diskType := labels["byot.io/disk-type"]
-	diskSize := labels["byot.io/disk-class"]
+	diskSize := labels["byot.io/disk-size"]
 
 	require.NotEmpty(t, cpu, "discovered byot.io/cpu-cores label must be set on %s", nodes.CPHost)
-	require.NotEmpty(t, memory, "discovered byot.io/memory-class label must be set on %s", nodes.CPHost)
+	require.NotEmpty(t, memory, "discovered byot.io/memory label must be set on %s", nodes.CPHost)
 
 	// Disk labels are optional: diskless hosts (e.g. Talos-in-Docker, which
 	// boots off overlay/tmpfs) promote no byot.io/disk-* labels. Only pin a disk
 	// selector when discovery actually found one; otherwise leave DiskType/
 	// DiskSize empty for a disk-agnostic selector the chart accepts.
 	if diskType != "" || diskSize != "" {
-		require.NotEmpty(t, diskType, "byot.io/disk-type set without byot.io/disk-class on %s", nodes.CPHost)
-		require.NotEmpty(t, diskSize, "byot.io/disk-class set without byot.io/disk-type on %s", nodes.CPHost)
+		require.NotEmpty(t, diskType, "byot.io/disk-type set without byot.io/disk-size on %s", nodes.CPHost)
+		require.NotEmpty(t, diskSize, "byot.io/disk-size set without byot.io/disk-type on %s", nodes.CPHost)
 	}
 
 	return helpers.ByotInfra{

--- a/pkg/test/helpers/byothelpers.go
+++ b/pkg/test/helpers/byothelpers.go
@@ -53,13 +53,13 @@ type ByotInfra struct {
 	// CPU is the resources.cpu value (plain integer string of physical cores)
 	// mapped to the byot.io/cpu-cores selector label.
 	CPU string
-	// Memory is the resources.memory bucket (4G 8G 16G 32G 64G 128G) mapped to
-	// the byot.io/memory-class selector label.
+	// Memory is the resources.memory value (e.g. 64G) mapped to
+	// the byot.io/memory selector label.
 	Memory string
 	// DiskType is the os.disk.type (nvme ssd hdd sd) mapped to byot.io/disk-type.
 	DiskType string
-	// DiskSize is the os.disk.size bucket (20G 100G 250G 500G 1T) mapped to
-	// byot.io/disk-class.
+	// DiskSize is the os.disk.size value (e.g. 250G 1T) mapped to
+	// byot.io/disk-size.
 	DiskSize string
 	// HostSelectorMatchLabels is an optional freeform operator label selector
 	// merged on top of the derived byot.io/ labels. Used here to scope a test's
@@ -942,7 +942,7 @@ func DeleteByotHost(t *testing.T, env TestEnvironment, name string, namespace st
 
 // ByotHostLabels returns the metadata.labels of a ByotHost. The host
 // controller promotes curated byot.io/ labels from discovery (cpu-cores,
-// memory-class, disk-type, disk-class, available, ...) and preserves operator
+// memory, disk-type, disk-size, available, ...) and preserves operator
 // (non-byot.io/) labels; tests read the promoted labels to build a matching
 // resources/os.disk selector.
 func ByotHostLabels(t *testing.T, env TestEnvironment, name string, namespace string) map[string]string {


### PR DESCRIPTION
Rename byot.io/memory-class to byot.io/memory and byot.io/disk-class to byot.io/disk-size, and replace the fixed disk-size bucket enum (20G 100G 250G 500G 1T) with a format check (integer + G/T suffix). The ByotHost controller now rounds capacities to the nearest GiB/TiB instead of bucketing, so every distinct value is a valid selector. Update the byot helm tests, values comments, and e2e helper/test label reads to match.

Signed-off-by: Paul Thuriot <pth@corti.ai>
